### PR TITLE
Disable the resource manager for now

### DIFF
--- a/main.go
+++ b/main.go
@@ -387,7 +387,7 @@ func initHost(ctx context.Context, dataDir string, listenAddrs ...multiaddr.Mult
 		panic("sanity check: peer key is uninitialized")
 	}
 
-	host, err := libp2p.New(libp2p.ListenAddrs(listenAddrs...), libp2p.Identity(peerkey))
+	host, err := libp2p.New(libp2p.ListenAddrs(listenAddrs...), libp2p.Identity(peerkey), libp2p.ResourceManager(network.NullResourceManager))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Goals

Logs still showing resource limits exceeded shortly before peer resets that are causing paid retrievals to fail :( For now the simple solution is to disable the resource manager.

We need a long term strategy for dealing with these issues in the resource manager.