### PR TITLE
Remove remaining possibilities of deadlock

### DIFF
--- a/blocks/manager_test.go
+++ b/blocks/manager_test.go
@@ -4,20 +4,76 @@ import (
 	"context"
 	"testing"
 
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/sync"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
 )
 
 func TestPutBlock(t *testing.T) {
-	ds := datastore.NewMapDatastore()
+	ctx := context.Background()
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	bs := blockstore.NewBlockstore(ds)
 	manager := newManager(bs)
-	ctx := context.Background()
 	blockGenerator := blocksutil.NewBlockGenerator()
 	blk := blockGenerator.Next()
+	receivedBlk := make(chan cid.Cid)
+	errChan := make(chan error, 1)
+	go func() {
+		err := manager.GetAwait(ctx, blk.Cid(), func(blk Block) {
+			receivedBlk <- blk.Cid()
+		})
+		if err != nil {
+			errChan <- err
+		}
+	}()
 	err := manager.Put(ctx, blk)
 	if err != nil {
 		t.Fatal("wasn't able to put to blockstore")
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatal("not enough succcesful blocks fetched")
+	case err := <-errChan:
+		t.Fatalf("received error getting block: %s", err)
+	case <-receivedBlk:
+	}
+}
+func TestPutMany(t *testing.T) {
+	ctx := context.Background()
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
+	bs := blockstore.NewBlockstore(ds)
+	manager := newManager(bs)
+	blockGenerator := blocksutil.NewBlockGenerator()
+	var blks []blocks.Block
+	for i := 0; i < 20; i++ {
+		blks = append(blks, blockGenerator.Next())
+	}
+	receivedBlocks := make(chan cid.Cid, 20)
+	errChan := make(chan error, 20)
+	go func() {
+		for _, blk := range blks {
+			err := manager.GetAwait(ctx, blk.Cid(), func(blk Block) {
+				receivedBlocks <- blk.Cid()
+			})
+			if err != nil {
+				errChan <- err
+			}
+		}
+	}()
+	err := manager.PutMany(ctx, blks)
+	if err != nil {
+		t.Fatal("wasn't able to put to blockstore")
+	}
+	for i := 0; i < 20; i++ {
+		select {
+		case <-ctx.Done():
+			t.Fatal("not enough succcesful blocks fetched")
+		case err := <-errChan:
+			t.Fatalf("received error getting block: %s", err)
+		case <-receivedBlocks:
+		}
 	}
 }


### PR DESCRIPTION
# Goals
While the previous fix gets us closer to what we want, it still has potential lock if you call PutMany with >10 blocks. 

# Implementation

Now that we have the go routine, there is actually no need for the lock in Put/PutMany. As long as GetAwait remains locked around the call to blockstore.Get and the modification of the waitlist, the worst that can happen is a Put happens during a simultaneous call to GetAwait in which case, either:
- The put finishes first and the get just returns immediately
- The get finishes first and puts a value on the waitlist, but then is immediately called in notifyWaitCallback

Also adds:
1. one missing unlock in Get
2. full functionality tests (note the TestPutMany will hang without the changes in this code)