### PR TITLE
Add CID blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ setting `AUTORETRIEVE_DATA_DIR`.
 You can use CLI flags or config files to blacklist or whitelist miners for
 autoretrieve downloads.
 
-To use CLI flags `--whitelist f0xxxx,f0yyyy` and `--blacklist f0zzzz,f0wwww`. If
+To use CLI flags `--miner-whitelist f0xxxx,f0yyyy` and `--miner-blacklist f0zzzz,f0wwww`. If
 set, the CLI flags will take precedence over config files.
 
-For a persistent blacklist or whitelist, create `blacklist.txt` and/or
-`whitelist.txt` in the data directory (`your-datadir` in the example above),
+For a persistent blacklist or whitelist, create `miner-blacklist.txt` and/or
+`miner-whitelist.txt` in the data directory (`your-datadir` in the example above),
 respectively, and populate them with a newline-separated listed of miner strings
 (text after `#` will be ignored):
 ```sh
@@ -49,8 +49,8 @@ USAGE:
    autoretrieve [global options] command [command options] [arguments...]
 
 COMMANDS:
-   check-blacklist  
-   check-whitelist  
+   check-miner-blacklist
+   check-miner-whitelist
    help, h          Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
@@ -64,7 +64,7 @@ GLOBAL OPTIONS:
    --fullrt                           Whether to use the full routing table instead of DHT (default: false) [$AUTORETRIEVE_USE_FULLRT]
    --log-resource-manager             Whether to present output about the current state of the libp2p resource manager (default: false) [$AUTORETRIEVE_LOG_RESOURCE_MANAGER]
    --log-retrievals                   Whether to present periodic output about the progress of retrievals (default: false) [$AUTORETRIEVE_LOG_RETRIEVALS]
-   --whitelist value                  Which miners to whitelist - overrides whitelist.txt
-   --blacklist value                  Which miners to blacklist - overrides blacklist.txt
+   --miner-whitelist value            Which miners to whitelist - overrides miner-whitelist.txt
+   --miner-blacklist value            Which miners to blacklist - overrides miner-blacklist.txt
    --help, -h                         show help (default: false)
 ```

--- a/README.md
+++ b/README.md
@@ -66,5 +66,6 @@ GLOBAL OPTIONS:
    --log-retrievals                   Whether to present periodic output about the progress of retrievals (default: false) [$AUTORETRIEVE_LOG_RETRIEVALS]
    --miner-whitelist value            Which miners to whitelist - overrides miner-whitelist.txt
    --miner-blacklist value            Which miners to blacklist - overrides miner-blacklist.txt
+   --cid-blacklist value              Which CIDs to blacklist - overrides cid-blacklist.txt
    --help, -h                         show help (default: false)
 ```

--- a/main.go
+++ b/main.go
@@ -41,18 +41,18 @@ import (
 
 var logger = log.Logger("autoretrieve")
 
-const minerBlacklistFilename = "blacklist.txt"
-const minerWhitelistFilename = "whitelist.txt"
+const minerBlacklistFilename = "miner-blacklist.txt"
+const minerWhitelistFilename = "miner-whitelist.txt"
 const datastoreSubdir = "datastore"
 const walletSubdir = "wallet"
 
-var flagWhitelist = &cli.StringSliceFlag{
-	Name:  "whitelist",
-	Usage: "Which miners to whitelist - overrides whitelist.txt",
+var flagMinerWhitelist = &cli.StringSliceFlag{
+	Name:  "miner-whitelist",
+	Usage: "Which miners to whitelist - overrides miner-whitelist.txt",
 }
-var flagBlacklist = &cli.StringSliceFlag{
-	Name:  "blacklist",
-	Usage: "Which miners to blacklist - overrides blacklist.txt",
+var flagMinerBlacklist = &cli.StringSliceFlag{
+	Name:  "miner-blacklist",
+	Usage: "Which miners to blacklist - overrides miner-blacklist.txt",
 }
 
 func main() {
@@ -116,22 +116,22 @@ func main() {
 			Usage:   "Whether to present periodic output about the progress of retrievals",
 			EnvVars: []string{"AUTORETRIEVE_LOG_RETRIEVALS"},
 		},
-		flagWhitelist,
-		flagBlacklist,
+		flagMinerWhitelist,
+		flagMinerBlacklist,
 	}
 
 	app.Action = run
 
 	app.Commands = []*cli.Command{
 		{
-			Name:   "check-blacklist",
-			Action: cmdCheckBlacklist,
-			Flags:  []cli.Flag{flagBlacklist},
+			Name:   "check-miner-blacklist",
+			Action: cmdCheckMinerBlacklist,
+			Flags:  []cli.Flag{flagMinerBlacklist},
 		},
 		{
-			Name:   "check-whitelist",
-			Action: cmdCheckWhitelist,
-			Flags:  []cli.Flag{flagWhitelist},
+			Name:   "check-miner-whitelist",
+			Action: cmdCheckMinerWhitelist,
+			Flags:  []cli.Flag{flagMinerWhitelist},
 		},
 	}
 
@@ -204,12 +204,12 @@ func run(cctx *cli.Context) error {
 	}()
 
 	// Load miner blacklist and whitelist
-	minerBlacklist, err := getBlacklist(cctx)
+	minerBlacklist, err := getMinerBlacklist(cctx)
 	if err != nil {
 		return err
 	}
 
-	minerWhitelist, err := getWhitelist(cctx)
+	minerWhitelist, err := getMinerWhitelist(cctx)
 	if err != nil {
 		return err
 	}
@@ -401,8 +401,8 @@ func run(cctx *cli.Context) error {
 var dtHeaders = "peer\tcid\tstatus\ttransferred\tmessage"
 var dtOutput = "%s\t%s\t%s\t%d\t%s\n"
 
-func cmdCheckBlacklist(cctx *cli.Context) error {
-	minerBlacklist, err := getBlacklist(cctx)
+func cmdCheckMinerBlacklist(cctx *cli.Context) error {
+	minerBlacklist, err := getMinerBlacklist(cctx)
 	if err != nil {
 		return err
 	}
@@ -419,8 +419,8 @@ func cmdCheckBlacklist(cctx *cli.Context) error {
 	return nil
 }
 
-func cmdCheckWhitelist(cctx *cli.Context) error {
-	minerWhitelist, err := getWhitelist(cctx)
+func cmdCheckMinerWhitelist(cctx *cli.Context) error {
+	minerWhitelist, err := getMinerWhitelist(cctx)
 	if err != nil {
 		return err
 	}
@@ -574,7 +574,7 @@ func parseMinerListArg(cctx *cli.Context, flagName string) (map[address.Address]
 }
 
 // Attempts to load the passed cli flag first - if empty, loads the file instead
-func getList(cctx *cli.Context, flagName string, path string) (map[address.Address]bool, error) {
+func getMinerList(cctx *cli.Context, flagName string, path string) (map[address.Address]bool, error) {
 	argList, err := parseMinerListArg(cctx, flagName)
 	if err != nil {
 		return nil, err
@@ -587,12 +587,12 @@ func getList(cctx *cli.Context, flagName string, path string) (map[address.Addre
 	return readMinerListFile(path)
 }
 
-func getWhitelist(cctx *cli.Context) (map[address.Address]bool, error) {
-	return getList(cctx, "whitelist", filepath.Join(cctx.String("datadir"), minerWhitelistFilename))
+func getMinerWhitelist(cctx *cli.Context) (map[address.Address]bool, error) {
+	return getMinerList(cctx, "miner-whitelist", filepath.Join(cctx.String("datadir"), minerWhitelistFilename))
 }
 
-func getBlacklist(cctx *cli.Context) (map[address.Address]bool, error) {
-	return getList(cctx, "blacklist", filepath.Join(cctx.String("datadir"), minerBlacklistFilename))
+func getMinerBlacklist(cctx *cli.Context) (map[address.Address]bool, error) {
+	return getMinerList(cctx, "miner-blacklist", filepath.Join(cctx.String("datadir"), minerBlacklistFilename))
 }
 
 func toMinerPeerList(ctx context.Context, fc *filclient.FilClient, minerList map[address.Address]bool) (map[peer.ID]bool, error) {


### PR DESCRIPTION
Adds a CID blacklist for preventing configured CIDs from being retrieved from storage providers.

This implementation specifically checks if the CID is in the blacklist before looking it up in the blockstore, and then responds with a DONT_HAVE if the CID is found in the blacklist.

The existing miner white and black list commands, functions, and variables were prefixed with the word "miner" where necessary to easily differentiate between the miner and CID lists.

The command option `--cid-blacklist value` was added, mimicking the behavior of the `--miner-whitelist` and `--miner-blacklist` options.

The sub command `check-cid-blacklist` was added, mimicking the behavior of the `check-miner-whitelist` and `check-miner-blacklist` sub commands.