### PR TITLE
Automate container image build and publish to ECR

### DIFF
--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -1,0 +1,50 @@
+name: ECR
+
+on:
+  release:
+    types:
+      - published
+  push:
+    paths-ignore:
+      - 'deploy/**'
+      - 'docs/**'
+    branches:
+      - master
+
+jobs:
+  publisher:
+    if: ${{ github.event.pusher.name != 'sti-bot' }}
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      ECR_REGISTRY: 407967248065.dkr.ecr.us-east-2.amazonaws.com/autoretrieve
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Determine Container Tag
+        run: |
+          IMAGE_TAG="${GITHUB_REF#refs/tags/v}"
+          if test "${IMAGE_TAG}" = "${GITHUB_REF}"; then
+            IMAGE_TAG="$(date '+%Y%m%d%H%M%S')-${GITHUB_SHA}"
+          fi
+          echo "Using image tag: ${IMAGE_TAG}"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+      - name: AWS Login
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-2
+          role-to-assume: "arn:aws:iam::407967248065:role/common/github_actions"
+          role-duration-seconds: 1200
+      - name: Login to Amazon ECR
+        run: aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+      - name: Publish Container Image
+        env:
+          DOCKER_BUILDKIT: '1'
+        run: |
+          IMAGE_NAME="${ECR_REGISTRY}/autoretrieve:${IMAGE_TAG}"
+          docker build -t "${IMAGE_NAME}" .
+          docker push "${IMAGE_NAME}"
+          echo "Published image ${IMAGE_NAME}"


### PR DESCRIPTION
Set up GitHub action job to build and publish the autoretrieve container
image to a repository set up in ECR at storetheindex AWS account.

The image tag is determined based on the build trigger: either merge to
 `master` or publication of a GitHub release.

If the build is triggered from merge to `main`, then the tag will follow
`timestamp-<commit-sha>` format. The rationale for this for mat is to
have some monotonically increasing numerical valu in the tag so that the
tags can be sortable by age. This is then used by Flux CD to determine
whether there is a new container image available for automated
deployment.

Otherwise, the release name is expected to be a semver starting with `v`
and the tag will be set to the semantic version stripping off the `v`
prefix.