### PR TITLE
Define application level manifests and dev deployment overlay

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,43 @@
+name: CD
+on:
+  push:
+    branches:
+      - 'cd/dev'
+
+jobs:
+  pull-request:
+    name: Open PR to master
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Create Pull Request
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const head = process.env.GITHUB_REF_NAME;
+            const env = head.replace(/cd\//g, '');
+            core.info(`Checking branch '${head}' for automated deployment to '${env}' environment...`);
+            
+            const { repo, owner } = context.repo;
+            try {
+              const result = await github.rest.pulls.create({
+                title: `Deploy latest to \`${env}\` environment`,
+                owner,
+                repo,
+                head,
+                base: 'master',
+                body: `Approve changes and merge this PR to trigger deployment to \`${env}\` environment.`
+              });
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: result.data.number,
+                labels: ['cd', `env:${env}`]
+              });
+            } catch (e) {
+              if (!e.message.includes('A pull request already exists')) {
+                throw e
+              }
+              core.info('Skipped PR creation since it already exists.')
+            }

--- a/deploy/manifests/base/config.yaml
+++ b/deploy/manifests/base/config.yaml
@@ -1,0 +1,16 @@
+endpoint-type: indexer
+endpoint-url: https://cid.contact
+max-bitswap-workers: 1
+use-fullrt: false
+prune-threshold: 0 B
+pin-duration: 1h0m0s
+log-resource-manager: false
+log-retrieval-stats: false
+disable-retrieval: false
+cid-blacklist: []
+miner-blacklist: []
+miner-whitelist: []
+default-miner-config:
+    retrieval-timeout: 1m0s
+    max-concurrent-retrievals: 1
+miner-configs: {}

--- a/deploy/manifests/base/deployment.yaml
+++ b/deploy/manifests/base/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoretrieve
+  namespace: autoretrieve
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: autoretrieve
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: autoretrieve
+    spec:
+      containers:
+        - name: autoretrieve
+          image: autoretrieve
+          args:
+            - --data-dir=/data
+          envFrom:
+            - configMapRef:
+                name: autoretrieve-env
+          ports:
+            - name: libp2p
+              containerPort: 6746
+            - name: admin
+              containerPort: 8080
+          readinessProbe:
+            tcpSocket:
+              port: libp2p
+          volumeMounts:
+            - name: config
+              mountPath: /data/.autoretrieve/config.yaml
+              subPath: config.yaml
+            - name: identity
+              mountPath: /data/.autoretrieve/peerkey
+              subPath: peerkey
+      volumes:
+        - name: config
+          configMap:
+            name: autoretrieve-config
+        - name: identity
+          secret:
+            secretName: autoretrieve-identity
+            items:
+              - key: peerkey.encrypted
+                path: ./peerkey

--- a/deploy/manifests/base/kustomization.yaml
+++ b/deploy/manifests/base/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: autoretrieve
+
+resources:
+  - deployment.yaml
+  - service.yaml
+
+configMapGenerator:
+  - name: autoretrieve-config
+    files:
+      - config.yaml
+  - name: autoretrieve-env
+    literals:
+      - FULLNODE_API_INFO=wss://api.chain.love
+
+secretGenerator:
+  - name: autoretrieve-identity
+    files:
+      - peerkey.encrypted

--- a/deploy/manifests/base/peerkey.encrypted
+++ b/deploy/manifests/base/peerkey.encrypted
@@ -1,0 +1,2 @@
+This is a placeholder file that should contain the encrypted marshalled Libp2p peer identity of the 
+autoretrieve host.

--- a/deploy/manifests/base/service.yaml
+++ b/deploy/manifests/base/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: autoretrieve-libp2p
+  namespace: autoretrieve
+  labels:
+    app: autoretrieve
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    external-dns.alpha.kubernetes.io/hostname: autoretrieve.dev.cid.contact
+spec:
+  ports:
+    - name: libp2p
+      port: 6746
+      targetPort: libp2p
+  selector:
+    app: autoretrieve
+  type: LoadBalancer

--- a/deploy/manifests/dev/us-east-2/.sops.yaml
+++ b/deploy/manifests/dev/us-east-2/.sops.yaml
@@ -1,0 +1,6 @@
+creation_rules:
+  - path_regex: '.+\.y(a)?ml'
+    encrypted_regex: '^(data|stringData)$'
+    kms: 'arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/autoretrieve'
+  - path_regex: '.*'
+    kms: 'arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/autoretrieve'

--- a/deploy/manifests/dev/us-east-2/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: autoretrieve
+
+resources:
+  - ../../base
+  - monitor.yaml
+
+patchesStrategicMerge:
+  - service-patch.yaml
+
+replicas:
+  - name: autoretrieve
+    count: 1
+
+secretGenerator:
+  - name: autoretrieve-identity
+    behavior: replace
+    files:
+      - peerkey.encrypted
+
+images:
+  - name: autoretrieve
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/autoretrieve/autoretrieve # {"$imagepolicy": "autoretrieve:autoretrieve:name"}
+    newTag: 20220512103615-07bc35e10c78bfe7085351d1b8e5bb206b82a2c8 # {"$imagepolicy": "autoretrieve:autoretrieve:tag"}

--- a/deploy/manifests/dev/us-east-2/monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: autoretrieve
+  labels:
+    app: autoretrieve
+spec:
+  selector:
+    matchLabels:
+      app: autoretrieve
+  namespaceSelector:
+    matchNames:
+      - autoretrieve
+  podMetricsEndpoints:
+    - path: /metrics
+      port: admin

--- a/deploy/manifests/dev/us-east-2/peerkey.encrypted
+++ b/deploy/manifests/dev/us-east-2/peerkey.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:72nBypiRKqUn3HO2K9i/PIgq4fAYNKWQV5+j1VcouHF/HsawocltDGrYf+0Yu2EfNZqTmvvyXFB6hznQUh7URrukV4k=,iv:Bx76oxUu5n99XR/hio5H1c3msIHeslyNLFNVXAh+oWk=,tag:r0rQjnhP1sbGi8epAR1aVg==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/autoretrieve",
+				"created_at": "2022-05-12T09:28:53Z",
+				"enc": "AQICAHgZ4zxFMLYL2iEHWJJh7edGwSAfx3nqUsNmImHieESc3QE9/NuMkmplXjGqWhElSvA+AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM2JK2G/a/5jVw9mvHAgEQgDurYy7vGOVqRzz2MQRHbIBqOZCdfsvbPrXZ0o5darXqkk1CwGxJkwy9ol8Mj12ZwMDHG15PDGTlho8f+w==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-05-12T09:28:54Z",
+		"mac": "ENC[AES256_GCM,data:T6HChP17UHP/2RLaQyLIslPtc8UCsfSgQr4mmYSODKaKvjFNZgf62f3a/loJkWMcLm1CFStz1hOqnoXXl4QjurDKyS6C7h2xghJTva7iTILpGWLG9ZyQQp9Lx1laTRdCYkrSGKoTU9mS+CF8ktyNlcT5aq+MTYKz9nLEx3ggcMo=,iv:r/cXqzYcv5aaYAN+VJIyRch4gYIxger7Pc5gxn/CozE=,tag:2UFh06SvmNC81SMjXrNk6A==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.7.2"
+	}
+}

--- a/deploy/manifests/dev/us-east-2/service-patch.yaml
+++ b/deploy/manifests/dev/us-east-2/service-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: autoretrieve-libp2p
+  namespace: autoretrieve
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    external-dns.alpha.kubernetes.io/hostname: autoretrieve.dev.cid.contact


### PR DESCRIPTION
Define the base K8S manifests along with placeholder for encrypted peer
identity. Define an overlay for `dev` `us-east-2` deployment to
storetheindex cluster.

The Peer ID is randomly generated and encrypted using `sops` which is
unencrypted on the fly at runtime by flux CD mechanism.

A service is defined to serve libp2p requests on port `6746`. This
service will use an AWS NLB with dns name `autoretrieve.dev.cid.contact`
in the dev overlay.

Pods' `/metrics` HTTP endpoint is monitored over port 8080 and metrics
are forwarded to `storetheindex-dev` Prometheus data source at
PL grafana. Logs are also automatically forwarded and should be aviable
at PL grafana provisioned Loki soruce, named
`grafanacloud-protocollabs-logs`.

A CI job is introduced to automatically create a PR for any new images
detected by flux CD. The automatic container image deployment flow is
the following:
- image is built and pushed to ECR up on merge to `master`
- flux cd on the K8S cluster detects the presense of a new image
- flux cd compares the currently deployed image with the new image
- if different, flux changes the manifests at
  `deploy/manifests/dev/us-east-2/kustomization.yaml` to point to the
  new image.
- flux cd then commits and pushes the canges to a branch named `cd/dev`.
- GitHub Actions is then triggered on pushes to `cd/dev` and creates a
  PR against `master`.
- repo maintainers review and merge the PR, and the merge of that PR
  results in a new deployment.

Note that the PR creation is engineered here on purpose to provide an
approval process through which deployemt will happen when there is a new
container release.

Changes to manifests located at `deploy/manifests`, however, will be
automatically deployed upon merge to `master`.