### PR TITLE
Set prune level to avoid pod being killed due to excessive disk usage

### DIFF
--- a/deploy/manifests/base/config.yaml
+++ b/deploy/manifests/base/config.yaml
@@ -2,7 +2,7 @@ endpoint-type: indexer
 endpoint-url: https://cid.contact
 max-bitswap-workers: 1
 use-fullrt: false
-prune-threshold: 0 B
+prune-threshold: 15 GB
 pin-duration: 1h0m0s
 log-resource-manager: false
 log-retrieval-stats: false


### PR DESCRIPTION
Set prune to 15 GB for now until the requirements for disk size are
determined.