### PR TITLE
Assign a dedicate PVC for cache with size 50GiB

### DIFF
--- a/deploy/manifests/base/config.yaml
+++ b/deploy/manifests/base/config.yaml
@@ -2,7 +2,7 @@ endpoint-type: indexer
 endpoint-url: https://cid.contact
 max-bitswap-workers: 1
 use-fullrt: false
-prune-threshold: 15 GB
+prune-threshold: 45 GB
 pin-duration: 1h0m0s
 log-resource-manager: false
 log-retrieval-stats: false

--- a/deploy/manifests/dev/us-east-2/deployment-patch.yaml
+++ b/deploy/manifests/dev/us-east-2/deployment-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoretrieve
+  namespace: autoretrieve
+spec:
+  template:
+    spec:
+      containers:
+        - name: autoretrieve
+          volumeMounts:
+            - name: cache
+              mountPath: /data
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: autoretrieve-cache-0

--- a/deploy/manifests/dev/us-east-2/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/kustomization.yaml
@@ -6,9 +6,11 @@ namespace: autoretrieve
 resources:
   - ../../base
   - monitor.yaml
+  - pvc.yaml
 
 patchesStrategicMerge:
   - service-patch.yaml
+  - deployment-patch.yaml
 
 replicas:
   - name: autoretrieve

--- a/deploy/manifests/dev/us-east-2/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: autoretrieve
+  name: autoretrieve-cache-0
+  namespace: autoretrieve
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: gp2


### PR DESCRIPTION
The dev instance is consistently evicted because it overuses the maximum
available ephemeral storage. Assign a dedicated PVC to the running
instance with the size of 50 GiB to avoid the pod being killed.