### PR TITLE
fix: update pvc storage to 500GiB

### DIFF
--- a/deploy/manifests/dev/us-east-2/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/pvc.yaml
@@ -10,5 +10,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 50Gi
+      storage: 500Gi
   storageClassName: gp2


### PR DESCRIPTION
Updates the PVC storage to 500GiB to match the manual autoretrieve instance we were running in EC2. Pruning was failing when PVC was 50GiB and pruning was 45GB. We're hoping to find the threshold for when autoretrieve stops falling over.