### PR TITLE
fix: add 32GiB memory resource limit and request

### DIFF
--- a/deploy/manifests/base/deployment.yaml
+++ b/deploy/manifests/base/deployment.yaml
@@ -38,6 +38,11 @@ spec:
             - name: identity
               mountPath: /data/.autoretrieve/peerkey
               subPath: peerkey
+          resources:
+            limits:
+              memory: 32Gi
+            requests:
+              memory: 32Gi
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
Autoretrieve is still running out of memory. Bumping the memory request to 32GiB, the size of a sector. The idea being a CID being requested might be the entire sector, so hopefully this is a high enough limit that it doesn't fall over as often.