### PR TITLE
Do not create a PR in CD branches if there is no commit

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,8 +36,8 @@ jobs:
                 labels: ['cd', `env:${env}`]
               });
             } catch (e) {
-              if (!e.message.includes('A pull request already exists')) {
+              if (!e.message.includes('A pull request already exists') && !e.message.includes('No commits between')) {
                 throw e
               }
-              core.info('Skipped PR creation since it already exists.')
+              core.info(`Skipped PR creation: ${e.message}`)
             }


### PR DESCRIPTION
The CI job that creates PRs from the `cd/dev` branch is triggered on
push. If a push is made to those branches where the is no commit from
the main branch to create a PR the build will fail.

Check the error message for a case where the CD branch is pushed to but
has no commits ahead of the main branch and gracefully terminate the
build.