### PR TITLE
feat: subscribe to filclient retrieval events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
-	github.com/application-research/filclient v0.0.0-20220602175911-a6b8faf9f1cd
+	github.com/application-research/filclient v0.0.0-20220622165741-3ca6a3f3bc7a
 	github.com/dustin/go-humanize v1.0.0
 	github.com/filecoin-project/go-address v0.0.6
 	github.com/filecoin-project/go-data-transfer v1.15.1

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/application-research/filclient v0.0.0-20220602175911-a6b8faf9f1cd h1:IF5gUAti2Dnqe6GoQS7oxAcj6Gy+RXYKEyM5tPFtJ3c=
 github.com/application-research/filclient v0.0.0-20220602175911-a6b8faf9f1cd/go.mod h1:QSOQ2dcnSvucj23jOg535mvTMezoNV0bdJbIySoDaOg=
+github.com/application-research/filclient v0.0.0-20220622165741-3ca6a3f3bc7a h1:Xw4boQwfwLqBV9dx69j43XOdokgFVjfZ+Dnd6l+KJw8=
+github.com/application-research/filclient v0.0.0-20220622165741-3ca6a3f3bc7a/go.mod h1:QSOQ2dcnSvucj23jOg535mvTMezoNV0bdJbIySoDaOg=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
Implement filclient retrieval subscriber into autoretrieve.

I was waffling on creating a new struct for the subscriber, but there currently isn't any additional state that needs to be retained, so I opted for making the retriever struct the subscriber.