### PR TITLE
feat: add HTTP event recorder reporting

### DIFF
--- a/autoretrieve.go
+++ b/autoretrieve.go
@@ -173,8 +173,9 @@ func New(cctx *cli.Context, dataDir string, cfg Config) (*Autoretrieve, error) {
 			return nil, err
 		}
 
-		var er *eventrecorder.EventRecorder
+		var er *eventrecorder.EventRecorder = nil
 		if cfg.EventRecorderEndpointURL != "" {
+			logger.Infof("Reporting events to %v", cfg.EventRecorderEndpointURL)
 			er = eventrecorder.NewEventRecorder(cfg.EventRecorderEndpointURL)
 		}
 

--- a/autoretrieve.go
+++ b/autoretrieve.go
@@ -19,6 +19,7 @@ import (
 	"github.com/application-research/autoretrieve/blocks"
 	"github.com/application-research/autoretrieve/endpoint"
 	"github.com/application-research/autoretrieve/filecoin"
+	"github.com/application-research/autoretrieve/filecoin/eventrecorder"
 	"github.com/application-research/filclient"
 	"github.com/application-research/filclient/keystore"
 	"github.com/filecoin-project/go-address"
@@ -172,15 +173,12 @@ func New(cctx *cli.Context, dataDir string, cfg Config) (*Autoretrieve, error) {
 			return nil, err
 		}
 
-		retriever, err = filecoin.NewRetriever(
-			retrieverCfg,
-			fc,
-			ep,
-			host,
-			api,
-			datastore,
-			blockManager,
-		)
+		var er *eventrecorder.EventRecorder
+		if cfg.EventRecorderEndpointURL != "" {
+			er = eventrecorder.NewEventRecorder(cfg.EventRecorderEndpointURL)
+		}
+
+		retriever, err = filecoin.NewRetriever(retrieverCfg, fc, ep, er)
 		if err != nil {
 			return nil, err
 		}

--- a/autoretrieve.go
+++ b/autoretrieve.go
@@ -173,15 +173,13 @@ func New(cctx *cli.Context, dataDir string, cfg Config) (*Autoretrieve, error) {
 			return nil, err
 		}
 
-		var er *eventrecorder.EventRecorder = nil
-		if cfg.EventRecorderEndpointURL != "" {
-			logger.Infof("Reporting events to %v", cfg.EventRecorderEndpointURL)
-			er = eventrecorder.NewEventRecorder(cfg.InstanceId, cfg.EventRecorderEndpointURL)
-		}
-
-		retriever, err = filecoin.NewRetriever(retrieverCfg, fc, ep, er)
+		retriever, err = filecoin.NewRetriever(retrieverCfg, fc, ep)
 		if err != nil {
 			return nil, err
+		}
+		if cfg.EventRecorderEndpointURL != "" {
+			logger.Infof("Reporting retrieval events to %v", cfg.EventRecorderEndpointURL)
+			retriever.RegisterListener(eventrecorder.NewEventRecorder(cfg.InstanceId, cfg.EventRecorderEndpointURL))
 		}
 		if cfg.LogRetrievals {
 			w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)

--- a/autoretrieve.go
+++ b/autoretrieve.go
@@ -176,7 +176,7 @@ func New(cctx *cli.Context, dataDir string, cfg Config) (*Autoretrieve, error) {
 		var er *eventrecorder.EventRecorder = nil
 		if cfg.EventRecorderEndpointURL != "" {
 			logger.Infof("Reporting events to %v", cfg.EventRecorderEndpointURL)
-			er = eventrecorder.NewEventRecorder(cfg.EventRecorderEndpointURL)
+			er = eventrecorder.NewEventRecorder(cfg.InstanceId, cfg.EventRecorderEndpointURL)
 		}
 
 		retriever, err = filecoin.NewRetriever(retrieverCfg, fc, ep, er)

--- a/autoretrieve.go
+++ b/autoretrieve.go
@@ -173,7 +173,7 @@ func New(cctx *cli.Context, dataDir string, cfg Config) (*Autoretrieve, error) {
 			return nil, err
 		}
 
-		retriever, err = filecoin.NewRetriever(retrieverCfg, fc, ep)
+		retriever, err = filecoin.NewRetriever(cctx.Context, retrieverCfg, fc, ep)
 		if err != nil {
 			return nil, err
 		}

--- a/bitswap/provider.go
+++ b/bitswap/provider.go
@@ -196,7 +196,7 @@ func (provider *Provider) ReceiveMessage(ctx context.Context, sender peer.ID, in
 				provider.queueDontHave(ctx, sender, entry, "failed_retriever_request")
 
 				if !errors.Is(err, filecoin.ErrNoCandidates) {
-					logger.Errorf("Could not get candidates: %v")
+					logger.Errorf("Could not get candidates: %s", err.Error())
 				}
 
 				continue
@@ -236,7 +236,7 @@ func (provider *Provider) ReceiveMessage(ctx context.Context, sender peer.ID, in
 }
 
 func (provider *Provider) ReceiveError(err error) {
-	logger.Errorf("Error receiving bitswap message: %v", err)
+	logger.Errorf("Error receiving bitswap message: %s", err.Error())
 }
 
 func (provider *Provider) PeerConnected(peer peer.ID) {}
@@ -283,7 +283,7 @@ func (provider *Provider) runWorker() {
 		msg.SetPendingBytes(int32(pending))
 
 		if err := provider.network.SendMessage(context.Background(), peer, msg); err != nil {
-			logger.Errorf("Failed to send message %#v: %v", msg, err)
+			logger.Errorf("Failed to send message %#v: %s", msg, err.Error())
 		}
 
 		provider.taskQueue.TasksDone(peer, tasks...)

--- a/config.go
+++ b/config.go
@@ -176,7 +176,7 @@ type Config struct {
 	MinerBlacklist           []ConfigStorageProvider  `yaml:"miner-blacklist"`
 	MinerWhitelist           []ConfigStorageProvider  `yaml:"miner-whitelist"`
 	EventRecorderEndpointURL string                   `yaml:"event-recorder-endpoint-url"`
-	InstanceId             string                   `yaml:"instance-name"`
+	InstanceId               string                   `yaml:"instance-name"`
 
 	DefaultMinerConfig MinerConfig                           `yaml:"default-miner-config"`
 	MinerConfigs       map[ConfigStorageProvider]MinerConfig `yaml:"miner-configs"`
@@ -239,7 +239,7 @@ func LoadConfig(path string) (Config, error) {
 
 func DefaultConfig() Config {
 	return Config{
-		InstanceId:       "autoretrieve-unnamed",
+		InstanceId:         "autoretrieve-unnamed",
 		LookupEndpointType: EndpointTypeIndexer,
 		LookupEndpointURL:  "https://cid.contact",
 		MaxBitswapWorkers:  1,

--- a/config.go
+++ b/config.go
@@ -160,21 +160,22 @@ type MinerConfig struct {
 
 // All config values should be safe to leave uninitialized
 type Config struct {
-	EstuaryURL         string                   `yaml:"estuary-url"`
-	AdvertiseInterval  time.Duration            `yaml:"advertise-interval"`
-	AdvertiseToken     string                   `yaml:"advertise-token"`
-	LookupEndpointType EndpointType             `yaml:"lookup-endpoint-type"`
-	LookupEndpointURL  string                   `yaml:"lookup-endpoint-url"`
-	MaxBitswapWorkers  uint                     `yaml:"max-bitswap-workers"`
-	RoutingTableType   bitswap.RoutingTableType `yaml:"routing-table-type"`
-	PruneThreshold     ConfigByteCount          `yaml:"prune-threshold"`
-	PinDuration        time.Duration            `yaml:"pin-duration"`
-	LogResourceManager bool                     `yaml:"log-resource-manager"`
-	LogRetrievals      bool                     `yaml:"log-retrieval-stats"`
-	DisableRetrieval   bool                     `yaml:"disable-retrieval"`
-	CidBlacklist       []cid.Cid                `yaml:"cid-blacklist"`
-	MinerBlacklist     []ConfigStorageProvider  `yaml:"miner-blacklist"`
-	MinerWhitelist     []ConfigStorageProvider  `yaml:"miner-whitelist"`
+	EstuaryURL               string                   `yaml:"estuary-url"`
+	AdvertiseInterval        time.Duration            `yaml:"advertise-interval"`
+	AdvertiseToken           string                   `yaml:"advertise-token"`
+	LookupEndpointType       EndpointType             `yaml:"lookup-endpoint-type"`
+	LookupEndpointURL        string                   `yaml:"lookup-endpoint-url"`
+	MaxBitswapWorkers        uint                     `yaml:"max-bitswap-workers"`
+	RoutingTableType         bitswap.RoutingTableType `yaml:"routing-table-type"`
+	PruneThreshold           ConfigByteCount          `yaml:"prune-threshold"`
+	PinDuration              time.Duration            `yaml:"pin-duration"`
+	LogResourceManager       bool                     `yaml:"log-resource-manager"`
+	LogRetrievals            bool                     `yaml:"log-retrieval-stats"`
+	DisableRetrieval         bool                     `yaml:"disable-retrieval"`
+	CidBlacklist             []cid.Cid                `yaml:"cid-blacklist"`
+	MinerBlacklist           []ConfigStorageProvider  `yaml:"miner-blacklist"`
+	MinerWhitelist           []ConfigStorageProvider  `yaml:"miner-whitelist"`
+	EventRecorderEndpointURL string                   `yaml:"event-recorder-endpoint-url"`
 
 	DefaultMinerConfig MinerConfig                           `yaml:"default-miner-config"`
 	MinerConfigs       map[ConfigStorageProvider]MinerConfig `yaml:"miner-configs"`

--- a/config.go
+++ b/config.go
@@ -176,6 +176,7 @@ type Config struct {
 	MinerBlacklist           []ConfigStorageProvider  `yaml:"miner-blacklist"`
 	MinerWhitelist           []ConfigStorageProvider  `yaml:"miner-whitelist"`
 	EventRecorderEndpointURL string                   `yaml:"event-recorder-endpoint-url"`
+	InstanceId             string                   `yaml:"instance-name"`
 
 	DefaultMinerConfig MinerConfig                           `yaml:"default-miner-config"`
 	MinerConfigs       map[ConfigStorageProvider]MinerConfig `yaml:"miner-configs"`
@@ -238,6 +239,7 @@ func LoadConfig(path string) (Config, error) {
 
 func DefaultConfig() Config {
 	return Config{
+		InstanceId:       "autoretrieve-unnamed",
 		LookupEndpointType: EndpointTypeIndexer,
 		LookupEndpointURL:  "https://cid.contact",
 		MaxBitswapWorkers:  1,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - AUTORETRIEVE_USE_FULLRT
       - AUTORETRIEVE_LOG_RESOURCE_MANAGER
       - AUTORETRIEVE_LOG_RETRIEVALS
+      - GOLOG_LOG_LEVEL
     ports: 
       - "6746:6746"
     volumes:

--- a/filecoin/activeretrievals.go
+++ b/filecoin/activeretrievals.go
@@ -60,7 +60,7 @@ func NewActiveRetrievalsManager() *ActiveRetrievalsManager {
 // provider candidates for each phase. Typically the retrievalCandidateCount
 // is unknown but setting it to zero may mean that a retrieval is considered
 // finished before we have a chance to set the correct number using a
-// subsequent call to RetrievalCandidateCount().
+// subsequent call to SetRetrievalCandidateCount().
 //
 // A unique ID is returned for the new retrieval that can be used to identify it
 // over the entire lifecycle.
@@ -95,17 +95,17 @@ func (arm *ActiveRetrievalsManager) New(retrievalCid cid.Cid, queryCandidateCoun
 	return retrievalId, nil
 }
 
-// RetrievalCandidateCount updates the number of storage provider candidates
+// SetRetrievalCandidateCount updates the number of storage provider candidates
 // once we know the number. When the number of finished retrievals equals this
 // number and the number of finished queries equals the query candidate count
 // the full retrieval is considered complete and can be cleaned up.
-func (arm *ActiveRetrievalsManager) RetrievalCandidateCount(retrievalCid cid.Cid, candidateCount int) {
+func (arm *ActiveRetrievalsManager) SetRetrievalCandidateCount(retrievalCid cid.Cid, candidateCount int) {
 	arm.lk.Lock()
 	defer arm.lk.Unlock()
 
 	ar := arm.findActiveRetrievalFor(retrievalCid)
 	if ar == nil {
-		log.Errorf("Unexpected active retrieval RetrievalCandidateCount for %s", retrievalCid)
+		log.Errorf("Unexpected active retrieval SetRetrievalCandidateCount for %s", retrievalCid)
 		return
 	}
 	ar.retrievalCandidateCount = candidateCount
@@ -114,11 +114,11 @@ func (arm *ActiveRetrievalsManager) RetrievalCandidateCount(retrievalCid cid.Cid
 	arm.maybeFinish(retrievalCid, ar)
 }
 
-// StatusFor fetches basic information for a retrieval, identified by the
+// GetStatusFor fetches basic information for a retrieval, identified by the
 // original retrieval CID (which may be different to the CID a storage provider
 // is being asked for). The phase is provided here in order to determine which
 // start time to return (query or retrieval).
-func (arm *ActiveRetrievalsManager) StatusFor(retrievalCid cid.Cid, phase rep.Phase) (uuid.UUID, cid.Cid, time.Time, bool) {
+func (arm *ActiveRetrievalsManager) GetStatusFor(retrievalCid cid.Cid, phase rep.Phase) (uuid.UUID, cid.Cid, time.Time, bool) {
 	arm.lk.RLock()
 	defer arm.lk.RUnlock()
 	ar := arm.findActiveRetrievalFor(retrievalCid)

--- a/filecoin/activeretrievals.go
+++ b/filecoin/activeretrievals.go
@@ -1,0 +1,252 @@
+package filecoin
+
+import (
+	"sync"
+	"time"
+
+	"github.com/application-research/filclient/rep"
+	"github.com/google/uuid"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+type activeRetrieval struct {
+	retrievalId              uuid.UUID
+	retrievalCid             cid.Cid
+	rootCid                  cid.Cid // for Estuary candidates, this can be different to retrievalCid & retrievals will report it so we have to track it
+	currentStorageProviderId peer.ID // for tracking concurrent SP counts
+	queryStartTime           time.Time
+	queryCandidateCount      int // number we expect queriesFinished to reach before query phase ends
+	queriesFinished          int
+	retrievalStartTime       time.Time
+	retrievalCandidateCount  int // number we expect retrievalsFinished to reach before retrieval phase ends
+	retrievalsFinished       int
+}
+
+// ActiveRetrievalsManager tracks the lifecycle of an active retrieval. This
+// currently includes two distinct phases: query, and retrieval. Each phase can
+// involve multiple storage providers. The query phase is assumed to be a
+// parallel operation while the retrieval phase is serial and we can therefore
+// track which single storage provider is currently involved in the retrieval.
+//
+// One purpose of the retrieval manager is to track the concurrency of
+// retrievals from individual storage providers. When attempting to set the
+// current storage provider to perform a retrieval with using the
+// SetRetrievalCandidate() call, the maximum number of concurrent retrievals
+// from that storage provider can be provided. We can then scan the currently
+// active retrievals and check that we don't exceed the maximum.
+//
+// The second purpose is to attach a UUID to each retrieval and match that to
+// events we receive from filclient so we can report each retrieval (all phases)
+// using a single unique identifier. Note that it is possible for the retrieval
+// phase to be operating against a different CID than the originally requested,
+// (rootCid vs retrievalCid - when using Estuary rather than the indexer). So
+// finding the right active retrieval is not straightforward.
+//
+// Determining the "end" of a retrieval is non-trivial since we need to match
+// the number of successes and failures of each phase against the expected
+// number for that phase. See maybeFinish().
+type ActiveRetrievalsManager struct {
+	arMap map[cid.Cid]*activeRetrieval
+	lk    sync.RWMutex
+}
+
+// NewActiveRetrievalsManager instantiates a new ActiveRetrievalsManager
+func NewActiveRetrievalsManager() *ActiveRetrievalsManager {
+	return &ActiveRetrievalsManager{arMap: make(map[cid.Cid]*activeRetrieval)}
+}
+
+// New registers a new retrieval, setting the expected number of storage
+// provider candidates for each phase. Typically the retrievalCandidateCount
+// is unknown but setting it to zero may mean that a retrieval is considered
+// finished before we have a chance to set the correct number using a
+// subsequent call to RetrievalCandidateCount().
+//
+// A unique ID is returned for the new retrieval that can be used to identify it
+// over the entire lifecycle.
+func (arm *ActiveRetrievalsManager) New(retrievalCid cid.Cid, queryCandidateCount int, retrievalCandidateCount int) (uuid.UUID, error) {
+	retrievalId, err := uuid.NewRandom()
+	if err != nil {
+		return uuid.UUID{}, err
+	}
+
+	arm.lk.Lock()
+	defer arm.lk.Unlock()
+
+	if arm.findActiveRetrievalFor(retrievalCid) != nil {
+		return uuid.UUID{}, ErrRetrievalAlreadyRunning
+	}
+
+	arm.arMap[retrievalCid] = &activeRetrieval{
+		retrievalId:              retrievalId,
+		retrievalCid:             retrievalCid,
+		rootCid:                  retrievalCid,
+		currentStorageProviderId: "",
+		queryStartTime:           time.Now(),
+		queryCandidateCount:      queryCandidateCount,
+		queriesFinished:          0,
+		retrievalStartTime:       time.Time{},
+		retrievalCandidateCount:  retrievalCandidateCount,
+		retrievalsFinished:       0,
+	}
+
+	log.Debugf("Registered new active retrieval for %s (%d active, %d/%d query candidates)", retrievalCid, len(arm.arMap), 0, queryCandidateCount)
+
+	return retrievalId, nil
+}
+
+// RetrievalCandidateCount updates the number of storage provider candidates
+// once we know the number. When the number of finished retrievals equals this
+// number and the number of finished queries equals the query candidate count
+// the full retrieval is considered complete and can be cleaned up.
+func (arm *ActiveRetrievalsManager) RetrievalCandidateCount(retrievalCid cid.Cid, candidateCount int) {
+	arm.lk.Lock()
+	defer arm.lk.Unlock()
+
+	ar := arm.findActiveRetrievalFor(retrievalCid)
+	if ar == nil {
+		log.Errorf("Unexpected active retrieval RetrievalCandidateCount for %s", retrievalCid)
+		return
+	}
+	ar.retrievalCandidateCount = candidateCount
+	ar.retrievalStartTime = time.Now()
+	log.Debugf("Updated active retrieval for %s to retrieval phase (%d active, %d/%d query candidates, %d/%d retrieval candidates)", retrievalCid, len(arm.arMap), ar.queriesFinished, ar.queryCandidateCount, ar.retrievalsFinished, ar.retrievalCandidateCount)
+	arm.maybeFinish(retrievalCid, ar)
+}
+
+// StatusFor fetches basic information for a retrieval, identified by the
+// original retrieval CID (which may be different to the CID a storage provider
+// is being asked for). The phase is provided here in order to determine which
+// start time to return (query or retrieval).
+func (arm *ActiveRetrievalsManager) StatusFor(retrievalCid cid.Cid, phase rep.Phase) (uuid.UUID, cid.Cid, time.Time, bool) {
+	arm.lk.RLock()
+	defer arm.lk.RUnlock()
+	ar := arm.findActiveRetrievalFor(retrievalCid)
+	if ar == nil {
+		return uuid.UUID{}, cid.Undef, time.Time{}, false
+	}
+	phaseStart := ar.queryStartTime
+	if phase == rep.RetrievalPhase {
+		phaseStart = ar.retrievalStartTime
+	}
+	return ar.retrievalId, ar.retrievalCid, phaseStart, true
+}
+
+// SetRetrievalCandidate updates the current storage provider that we are
+// performing a retrieval (not query) from. It also sets the root CID for this
+// candidate, which may be different to the originally requested CID.
+//
+// If the maxConcurrent is non-zero, the number of concurrent retrievals (not
+// including queries) being performed from this storage provider is checked and
+// if an additional retrieval would exceed this number ErrHitRetrievalLimit is
+// returned without performing the update.
+func (arm *ActiveRetrievalsManager) SetRetrievalCandidate(retrievalCid, rootCid cid.Cid, storageProviderId peer.ID, maxConcurrent uint) error {
+	arm.lk.Lock()
+	defer arm.lk.Unlock()
+
+	ar := arm.findActiveRetrievalFor(retrievalCid)
+	if ar == nil {
+		log.Errorf("Unexpected active retrieval SetRetrievalCandidate for %s", retrievalCid)
+		return ErrUnexpectedRetrieval
+	}
+
+	// If limit is enabled (non-zero) and we have already hit it, we can't
+	// allow this retrieval to start
+	if maxConcurrent > 0 {
+		var currentRetrievals uint
+		for _, ret := range arm.arMap {
+			if ret.currentStorageProviderId == storageProviderId {
+				currentRetrievals++
+			}
+		}
+		if currentRetrievals >= maxConcurrent {
+			ar.retrievalsFinished++ // this retrieval won't start so we won't get events for it, treat it as finished
+			arm.maybeFinish(retrievalCid, ar)
+			return ErrHitRetrievalLimit
+		}
+	}
+
+	ar.currentStorageProviderId = storageProviderId
+	ar.rootCid = rootCid
+
+	return nil
+}
+
+// QueryCandidatedFinished registers that a query has finished with one of the
+// query candidates. It's used to increment the number of finished queries and
+// also check whether cleanup may be necessary.
+func (arm *ActiveRetrievalsManager) QueryCandidatedFinished(retrievalCid cid.Cid) {
+	arm.lk.Lock()
+	defer arm.lk.Unlock()
+
+	ar := arm.findActiveRetrievalFor(retrievalCid)
+	if ar == nil {
+		log.Errorf("Unexpected active retrieval QueryCandidatedFinished for %s (%d active, %d/%d query candidates, %d/%d retrieval candidates)", retrievalCid, len(arm.arMap), ar.queriesFinished, ar.queryCandidateCount, ar.retrievalsFinished, ar.retrievalCandidateCount)
+		return
+	}
+	ar.queriesFinished++
+	log.Debugf("QueryCandidatedFinished for %s (%d active, %d/%d query candidates, %d/%d retrieval candidates)", retrievalCid, len(arm.arMap), ar.queriesFinished, ar.queryCandidateCount, ar.retrievalsFinished, ar.retrievalCandidateCount)
+	arm.maybeFinish(retrievalCid, ar)
+}
+
+// RetrievalCandidatedFinished registers that a retrieval has finished with one
+// of the query candidates. In the case of a failure, it's used to increment the
+// number of finished so we can check the finished count against the number of
+// expected candidates for possible clean-up. In the case of success, we can
+// assume no more retrievals will occur so we can jump straight to clean-up.
+func (arm *ActiveRetrievalsManager) RetrievalCandidatedFinished(retrievalCid cid.Cid, success bool) {
+	arm.lk.Lock()
+	defer arm.lk.Unlock()
+
+	ar := arm.findActiveRetrievalFor(retrievalCid)
+	if ar == nil {
+		log.Errorf("Unexpected active retrieval RetrievalCandidatedFinished for %s (%d active, %d/%d query candidates, %d/%d retrieval candidates)", retrievalCid, len(arm.arMap), ar.queriesFinished, ar.queryCandidateCount, ar.retrievalsFinished, ar.retrievalCandidateCount)
+		return
+	}
+	ar.retrievalsFinished++
+	if success {
+		// if success, there won't be any more retrieval attempts so we can short-circuit clean-up
+		ar.retrievalCandidateCount = ar.retrievalsFinished
+	}
+	log.Debugf("RetrievalCandidatedFinished for %s (%d active, %d/%d query candidates, %d/%d retrieval candidates)", retrievalCid, len(arm.arMap), ar.queriesFinished, ar.queryCandidateCount, ar.retrievalsFinished, ar.retrievalCandidateCount)
+	arm.maybeFinish(retrievalCid, ar)
+}
+
+// findActiveRetrievalFor looks up a retrieval in the map by CID but will also
+// search for rootCid matches as a secondary option since they can also be
+// identified by that way.
+// Note that one implication of looking up a CID in both places is that calls to
+// New() will return ErrRetrievalAlreadyRunning if that CID is involved as
+// either a primary CID or a root CID. But this is reasonable since a successful
+// retrieval will yield the newly requested CID regardless.
+func (arm *ActiveRetrievalsManager) findActiveRetrievalFor(cid cid.Cid) *activeRetrieval {
+	ar, ok := arm.arMap[cid]
+	if !ok {
+		for _, ar := range arm.arMap {
+			if cid.Equals(ar.rootCid) {
+				return ar
+			}
+		}
+	}
+	return ar
+}
+
+// maybeFinish checks whether we've completed all expected queries and
+// retrievals, and if so, cleans up the record. "complete" means that we've
+// recorded a finish for the expected number of queries and retrievals.
+// This function expects the lock to be held by the caller!
+func (arm *ActiveRetrievalsManager) maybeFinish(retrievalCid cid.Cid, ar *activeRetrieval) {
+	if ar.queriesFinished >= ar.queryCandidateCount && ar.retrievalsFinished >= ar.retrievalCandidateCount {
+		if ar.retrievalCid.Equals(retrievalCid) {
+			delete(arm.arMap, retrievalCid)
+		} else {
+			for _, ar := range arm.arMap {
+				if retrievalCid.Equals(ar.rootCid) {
+					delete(arm.arMap, ar.retrievalCid)
+					break
+				}
+			}
+		}
+		log.Debugf("Unregistered active retrieval for %s (%d active, %d/%d query candidates, %d/%d retrieval candidates)", retrievalCid, len(arm.arMap), ar.queriesFinished, ar.queryCandidateCount, ar.retrievalsFinished, ar.retrievalCandidateCount)
+	}
+}

--- a/filecoin/activeretrievals_test.go
+++ b/filecoin/activeretrievals_test.go
@@ -1,0 +1,242 @@
+package filecoin_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/application-research/autoretrieve/filecoin"
+	"github.com/application-research/filclient/rep"
+	qt "github.com/frankban/quicktest"
+	"github.com/ipfs/go-cid"
+)
+
+var testCid1 cid.Cid = mustCid("bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4bhnyiu6h7pm")
+var testCid2 cid.Cid = mustCid("bafyrgqhai26anf3i7pips7q22coa4sz2fr4gk4q4sqdtymvvjyginfzaqewveaeqdh524nsktaq43j65v22xxrybrtertmcfxufdam3da3hbk")
+
+func TestActiveRetrievalsManager_GetStatusFor(t *testing.T) {
+	arm := filecoin.NewActiveRetrievalsManager()
+	id, err := arm.New(testCid1, 1, 1)
+	qt.Assert(t, err, qt.IsNil)
+
+	sid, scid, sqtime, has := arm.GetStatusFor(testCid1, rep.QueryPhase)
+	qt.Assert(t, has, qt.IsTrue)
+	qt.Assert(t, sid, qt.Equals, id)
+	qt.Assert(t, scid, qt.Equals, testCid1)
+	qt.Assert(t, sqtime.Truncate(time.Microsecond*1).UnixMilli(), qt.Equals, time.Now().Truncate(time.Microsecond*1).UnixMilli())
+
+	_, _, _, has = arm.GetStatusFor(testCid2, rep.QueryPhase)
+	qt.Assert(t, has, qt.IsFalse)
+
+	arm.QueryCandidatedFinished(testCid1)
+	_, _, stime, has := arm.GetStatusFor(testCid1, rep.QueryPhase)
+	qt.Assert(t, has, qt.IsTrue)
+	qt.Assert(t, stime, qt.Equals, sqtime) // should be identical to the first call, we're still in query phase
+
+	_, _, stime, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+	qt.Assert(t, has, qt.IsTrue)
+	qt.Assert(t, stime, qt.Equals, time.Time{}) // haven't started retrieval phase yet
+
+	// start retrieval phase
+	arm.SetRetrievalCandidateCount(testCid1, 1)
+	sid, scid, srtime, has := arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+	qt.Assert(t, has, qt.IsTrue)
+	qt.Assert(t, sid, qt.Equals, id)
+	qt.Assert(t, scid, qt.Equals, testCid1)
+	qt.Assert(t, srtime.Truncate(time.Microsecond*1).UnixMilli(), qt.Equals, time.Now().Truncate(time.Microsecond*1).UnixMilli())
+	qt.Assert(t, srtime, qt.Not(qt.Equals), sqtime) // different phase start time
+
+	_, _, stime, has = arm.GetStatusFor(testCid1, rep.QueryPhase)
+	qt.Assert(t, has, qt.IsTrue)
+	qt.Assert(t, sid, qt.Equals, id)
+	qt.Assert(t, scid, qt.Equals, testCid1)
+	qt.Assert(t, stime, qt.Equals, sqtime) // should still be the same as original query phase time
+
+	_, _, rtime, has := arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+	qt.Assert(t, has, qt.IsTrue)
+	qt.Assert(t, sid, qt.Equals, id)
+	qt.Assert(t, scid, qt.Equals, testCid1)
+	qt.Assert(t, rtime, qt.Equals, srtime) // should match the original retrieval phase start time we got
+
+	// set a retrieval candidate with a different root CID
+	err = arm.SetRetrievalCandidate(testCid1, testCid2, "", 0)
+	qt.Assert(t, err, qt.IsNil)
+
+	// statuses with the testCid1 are still the same
+	_, _, stime, has = arm.GetStatusFor(testCid1, rep.QueryPhase)
+	qt.Assert(t, has, qt.IsTrue)
+	qt.Assert(t, sid, qt.Equals, id)
+	qt.Assert(t, scid, qt.Equals, testCid1)
+	qt.Assert(t, stime, qt.Equals, sqtime)
+
+	_, _, rtime, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+	qt.Assert(t, has, qt.IsTrue)
+	qt.Assert(t, sid, qt.Equals, id)
+	qt.Assert(t, scid, qt.Equals, testCid1)
+	qt.Assert(t, rtime, qt.Equals, srtime)
+
+	// statuses with the testCid2 should also work now
+	_, _, stime, has = arm.GetStatusFor(testCid2, rep.QueryPhase)
+	qt.Assert(t, has, qt.IsTrue)
+	qt.Assert(t, sid, qt.Equals, id)
+	qt.Assert(t, scid, qt.Equals, testCid1)
+	qt.Assert(t, stime, qt.Equals, sqtime)
+
+	_, _, rtime, has = arm.GetStatusFor(testCid2, rep.RetrievalPhase)
+	qt.Assert(t, has, qt.IsTrue)
+	qt.Assert(t, sid, qt.Equals, id)
+	qt.Assert(t, scid, qt.Equals, testCid1)
+	qt.Assert(t, rtime, qt.Equals, srtime)
+}
+
+func TestActiveRetrievalsManager_NoRetrievalPhase(t *testing.T) {
+	t.Run("in-order", func(t *testing.T) {
+		arm := filecoin.NewActiveRetrievalsManager()
+		_, err := arm.New(testCid1, 1, 1)
+		qt.Assert(t, err, qt.IsNil)
+
+		arm.QueryCandidatedFinished(testCid1)
+		_, _, _, has := arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+
+		arm.SetRetrievalCandidateCount(testCid1, 0) // should trigger a clean-up
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsFalse)
+	})
+
+	t.Run("out-of-order", func(t *testing.T) {
+		arm := filecoin.NewActiveRetrievalsManager()
+		_, err := arm.New(testCid1, 1, 1)
+		qt.Assert(t, err, qt.IsNil)
+
+		arm.SetRetrievalCandidateCount(testCid1, 0)
+		_, _, _, has := arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+
+		arm.QueryCandidatedFinished(testCid1) // should trigger a clean-up
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsFalse)
+	})
+}
+
+func TestActiveRetrievalsManager_BothPhases(t *testing.T) {
+	t.Run("single-each-success", func(t *testing.T) {
+		arm := filecoin.NewActiveRetrievalsManager()
+		_, err := arm.New(testCid1, 1, 1)
+		qt.Assert(t, err, qt.IsNil)
+
+		arm.QueryCandidatedFinished(testCid1)
+		_, _, _, has := arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+
+		arm.SetRetrievalCandidateCount(testCid1, 1)
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+
+		arm.RetrievalCandidatedFinished(testCid1, true)
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsFalse)
+	})
+
+	// should work identical to the single-each-success case
+	t.Run("single-each-failure", func(t *testing.T) {
+		arm := filecoin.NewActiveRetrievalsManager()
+		_, err := arm.New(testCid1, 1, 1)
+		qt.Assert(t, err, qt.IsNil)
+
+		arm.QueryCandidatedFinished(testCid1)
+		_, _, _, has := arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+
+		arm.SetRetrievalCandidateCount(testCid1, 1)
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+
+		arm.RetrievalCandidatedFinished(testCid1, false)
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsFalse)
+	})
+
+	t.Run("multiple-each-failure", func(t *testing.T) {
+		arm := filecoin.NewActiveRetrievalsManager()
+		_, err := arm.New(testCid1, 3, 1)
+		qt.Assert(t, err, qt.IsNil)
+
+		arm.QueryCandidatedFinished(testCid1)
+		arm.QueryCandidatedFinished(testCid1)
+		arm.QueryCandidatedFinished(testCid1)
+		_, _, _, has := arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+
+		arm.SetRetrievalCandidateCount(testCid1, 3)
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+
+		arm.RetrievalCandidatedFinished(testCid1, false)
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+		arm.RetrievalCandidatedFinished(testCid1, false)
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+		arm.RetrievalCandidatedFinished(testCid1, false) // expect clean-up
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsFalse)
+	})
+
+	t.Run("multiple-each-success", func(t *testing.T) {
+		arm := filecoin.NewActiveRetrievalsManager()
+		_, err := arm.New(testCid1, 3, 1)
+		qt.Assert(t, err, qt.IsNil)
+
+		arm.QueryCandidatedFinished(testCid1)
+		arm.QueryCandidatedFinished(testCid1)
+		arm.QueryCandidatedFinished(testCid1)
+		_, _, _, has := arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+
+		arm.SetRetrievalCandidateCount(testCid1, 3)
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+
+		arm.RetrievalCandidatedFinished(testCid1, false)
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+		arm.RetrievalCandidatedFinished(testCid1, true) // expect early clean-up
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsFalse)
+	})
+
+	// unrealistic, but potential in a very racy situation
+	t.Run("multiple-each-out-of-order", func(t *testing.T) {
+		arm := filecoin.NewActiveRetrievalsManager()
+		_, err := arm.New(testCid1, 3, 1)
+		qt.Assert(t, err, qt.IsNil)
+
+		arm.QueryCandidatedFinished(testCid1)
+		arm.QueryCandidatedFinished(testCid1)
+		_, _, _, has := arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+
+		arm.SetRetrievalCandidateCount(testCid1, 3)
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+
+		arm.RetrievalCandidatedFinished(testCid1, false)
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+		arm.RetrievalCandidatedFinished(testCid1, true)
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsTrue)
+
+		arm.QueryCandidatedFinished(testCid1) // delayed clean-up
+		_, _, _, has = arm.GetStatusFor(testCid1, rep.RetrievalPhase)
+		qt.Assert(t, has, qt.IsFalse)
+	})
+}
+
+func mustCid(cstr string) cid.Cid {
+	c, err := cid.Decode(cstr)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}

--- a/filecoin/eventrecorder/eventrecorder.go
+++ b/filecoin/eventrecorder/eventrecorder.go
@@ -39,9 +39,6 @@ type eventReport struct {
 	Event             rep.RetrievalEventCode `json:"event"`
 	EventTime         time.Time              `json:"eventTime"`
 	EventDetails      interface{}            `json:"eventDetails"`
-	/*
-		QueryResponse *retrievalmarket.QueryResponse `json:"queryResponse,omitempty"`
-	*/
 }
 
 type eventDetailsSuccess struct {

--- a/filecoin/eventrecorder/eventrecorder.go
+++ b/filecoin/eventrecorder/eventrecorder.go
@@ -127,7 +127,7 @@ func (er *EventRecorder) RecordFailure(
 }
 
 func (er *EventRecorder) recordEvent(retrievalId uuid.UUID, minerId peer.ID, evt event) error {
-	// https://.../event/~uuid~/providers/~peerID
+	// https://.../retrieval-event/~uuid~/providers/~peerID~
 	url := fmt.Sprintf("%s/retrieval-event/%s/providers/%s", er.endpointURL, retrievalId.String(), minerId.String())
 
 	node := bindnode.Wrap(&evt, eventType)
@@ -135,18 +135,16 @@ func (er *EventRecorder) recordEvent(retrievalId uuid.UUID, minerId peer.ID, evt
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest("PUT", url, bytes.NewReader(byts))
+	req, err := http.NewRequest("PUT", url, bytes.NewBufferString(string(byts)))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}
-	_ = resp.Body.Close() // error not so important at this point
+	defer resp.Body.Close() // error not so important at this point
 	return nil
 }
 

--- a/filecoin/eventrecorder/eventrecorder.go
+++ b/filecoin/eventrecorder/eventrecorder.go
@@ -56,23 +56,9 @@ type eventDetailsError struct {
 	Error string `json:"error"`
 }
 
-// newEventReport is just a utility to make sure we are properly filling up the
-// struct and not forgetting any properties
-func (er EventRecorder) newEventReport(
-	retrievalId uuid.UUID,
-	retrievalCid cid.Cid,
-	storageProviderId peer.ID,
-	phase rep.Phase,
-	phaseStartTime time.Time,
-	event rep.RetrievalEventCode,
-	eventTime time.Time,
-) eventReport {
-	return eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, phase, phaseStartTime, event, eventTime, nil}
-}
-
 // QueryProgress events occur during the query process
 func (er *EventRecorder) QueryProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, event rep.RetrievalEventCode) {
-	evt := er.newEventReport(retrievalId, retrievalCid, storageProviderId, rep.QueryPhase, phaseStartTime, event, eventTime)
+	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.QueryPhase, phaseStartTime, event, eventTime, nil}
 	er.recordEvent("QueryProgress", evt)
 }
 
@@ -80,7 +66,7 @@ func (er *EventRecorder) QueryProgress(retrievalId uuid.UUID, phaseStartTime, ev
 // provider. A query will result in either a QueryFailure or
 // a QuerySuccess event.
 func (er *EventRecorder) QueryFailure(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, errorString string) {
-	evt := er.newEventReport(retrievalId, retrievalCid, storageProviderId, rep.QueryPhase, phaseStartTime, rep.RetrievalEventFailure, eventTime)
+	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.QueryPhase, phaseStartTime, rep.RetrievalEventFailure, eventTime, nil}
 	evt.EventDetails = &eventDetailsError{errorString}
 	er.recordEvent("QueryFailure", evt)
 }
@@ -89,7 +75,7 @@ func (er *EventRecorder) QueryFailure(retrievalId uuid.UUID, phaseStartTime, eve
 // provider. A query will result in either a QueryFailure or
 // a QuerySuccess event.
 func (er *EventRecorder) QuerySuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse) {
-	evt := er.newEventReport(retrievalId, retrievalCid, storageProviderId, rep.QueryPhase, phaseStartTime, rep.RetrievalEventQueryAsk, eventTime)
+	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.QueryPhase, phaseStartTime, rep.RetrievalEventQueryAsk, eventTime, nil}
 	evt.EventDetails = &queryResponse
 	er.recordEvent("QuerySuccess", evt)
 }
@@ -98,7 +84,7 @@ func (er *EventRecorder) QuerySuccess(retrievalId uuid.UUID, phaseStartTime, eve
 // Success and failure progress event types are not reported here, but are
 // signalled via RetrievalSuccess or RetrievalFailure.
 func (er *EventRecorder) RetrievalProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, event rep.RetrievalEventCode) {
-	evt := er.newEventReport(retrievalId, retrievalCid, storageProviderId, rep.RetrievalPhase, phaseStartTime, event, eventTime)
+	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.RetrievalPhase, phaseStartTime, event, eventTime, nil}
 	er.recordEvent("RetrievalProgress", evt)
 }
 
@@ -106,7 +92,7 @@ func (er *EventRecorder) RetrievalProgress(retrievalId uuid.UUID, phaseStartTime
 // will result in either a QueryFailure or a QuerySuccess
 // event.
 func (er *EventRecorder) RetrievalSuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, retrievedSize uint64) {
-	evt := er.newEventReport(retrievalId, retrievalCid, storageProviderId, rep.RetrievalPhase, phaseStartTime, rep.RetrievalEventSuccess, eventTime)
+	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.RetrievalPhase, phaseStartTime, rep.RetrievalEventSuccess, eventTime, nil}
 	evt.EventDetails = &eventDetailsSuccess{retrievedSize}
 	er.recordEvent("RetrievalSuccess", evt)
 }
@@ -115,7 +101,7 @@ func (er *EventRecorder) RetrievalSuccess(retrievalId uuid.UUID, phaseStartTime,
 // will result in either a QueryFailure or a QuerySuccess
 // event.
 func (er *EventRecorder) RetrievalFailure(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, errorString string) {
-	evt := er.newEventReport(retrievalId, retrievalCid, storageProviderId, rep.RetrievalPhase, phaseStartTime, rep.RetrievalEventFailure, eventTime)
+	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.RetrievalPhase, phaseStartTime, rep.RetrievalEventFailure, eventTime, nil}
 	evt.EventDetails = &eventDetailsError{errorString}
 	er.recordEvent("RetrievalFailure", evt)
 }

--- a/filecoin/eventrecorder/eventrecorder.go
+++ b/filecoin/eventrecorder/eventrecorder.go
@@ -2,31 +2,26 @@ package eventrecorder
 
 import (
 	"bytes"
-	"errors"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/application-research/autoretrieve/filecoin"
-	"github.com/application-research/filclient"
 	"github.com/application-research/filclient/rep"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/ipld/go-ipld-prime"
-	"github.com/ipld/go-ipld-prime/codec/dagjson"
-	"github.com/ipld/go-ipld-prime/node/bindnode"
-	"github.com/ipld/go-ipld-prime/schema"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 var _ filecoin.RetrievalEventListener = (*EventRecorder)(nil)
 
-var log = logging.Logger("filecoin")
+var log = logging.Logger("eventrecorder")
 
 func NewEventRecorder(instanceId string, endpointURL string) *EventRecorder {
-	return &EventRecorder{instanceId, endpointURL}
+	return &EventRecorder{instanceId, fmt.Sprintf("%s/retrieval-events", endpointURL)}
 }
 
 type EventRecorder struct {
@@ -34,272 +29,112 @@ type EventRecorder struct {
 	endpointURL string
 }
 
-var eventSchema string = `
-type event struct {
-	instanceId              String # Set in the autoretrieve config
-	cid                     Link   # The CID that was originally requested
-	rootCid        optional Link   # The CID that we are retrieving _if_ it's different to the originally requested CID (only set on "start" event)
-	time                    String # The timestamp of this event
-	stage                   String # The stage of this event (see filclient/rep/RetrievalEventCode - plus a custom "start" event)
-	candidateCount optional Int    # For the start of a query, expect this number of query failures or successes
-
-	queryResponse  optional eventQueryResponse    # For a successful query
-	success        optional eventRetrievalSuccess # For a successful retrieval
-	error          optional String                # The full error message for an unsuccessful query or retrieval
+type eventReport struct {
+	RetrievalId       uuid.UUID              `json:"retrievalId"`
+	InstanceId        string                 `json:"instanceId"`
+	Cid               string                 `json:"cid"`
+	StorageProviderId peer.ID                `json:"storageProviderId"`
+	Phase             rep.Phase              `json:"phase"`
+	PhaseStartTime    time.Time              `json:"phaseStartTime"`
+	Event             rep.RetrievalEventCode `json:"event"`
+	EventTime         time.Time              `json:"eventTime"`
+	EventDetails      interface{}            `json:"eventDetails"`
+	/*
+		QueryResponse *retrievalmarket.QueryResponse `json:"queryResponse,omitempty"`
+	*/
 }
 
-type eventRetrievalSuccess struct {
-	status                     Int
-	pieceCidFound              Int    # if a PieceCID was requested, the result
-	size                       Int    # Total size of piece in bytes
-	paymentAddress             String # (address.Address) address to send funds to
-	minPricePerByte            String # abi.TokenAmount
-	maxPaymentInterval         Int
-	maxPaymentIntervalIncrease Int
-	message                    String
-	unsealPrice                String # abi.TokenAmount
+type eventDetailsSuccess struct {
+	ReceivedSize uint64 `json:"receivedSize,omitempty"`
 }
 
-type eventQueryResponse struct {
-	size         Int    # Size in bytes of the transfer
-	askPrice     String # The asking price from the storage provider
-	totalPayment String # The total payment that was transferred to the miner
-	numPayments  Int    # The number of separate payments made during the retrieval
-}
-`
-
-// TODO: use time.Time and abi.TokenAmount and use bindnode converters to convert to strings
-// when we can upgrade to >=go-ipld-prime@v0.17.0
-type event struct {
-	InstanceId     string
-	Cid            cid.Cid  // will use dag-json CID style thanks to Cid#MarshalJSON
-	RootCid        *cid.Cid // ditto ^
-	Time           string   // time.RFC3339Nano format
-	Stage          string
-	CandidateCount *int // number of candidates available for querying for this CID
-	Success        *eventRetrievalSuccess
-	QueryResponse  *eventQueryResponse
-	Error          *string
+type eventDetailsError struct {
+	Error string `json:"error,omitempty"`
 }
 
-type eventRetrievalSuccess struct {
-	Size         uint64
-	AskPrice     string // abi.TokenAmount / big.Int
-	TotalPayment string // abi.TokenAmount / big.Int
-	NumPayments  uint
+func (er EventRecorder) newEventReport(
+	retrievalId uuid.UUID,
+	retrievalCid cid.Cid,
+	storageProviderId peer.ID,
+	phase rep.Phase,
+	phaseStartTime time.Time,
+	event rep.RetrievalEventCode,
+	eventTime time.Time,
+) eventReport {
+	return eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, phase, phaseStartTime, event, eventTime, nil}
 }
 
-type eventQueryResponse struct {
-	Status                     uint64
-	PieceCIDFound              uint64 // if a PieceCID was requested, the result
-	Size                       uint64 // Total size of piece in bytes
-	PaymentAddress             string // (address.Address) address to send funds to
-	MinPricePerByte            string // abi.TokenAmount
-	MaxPaymentInterval         uint64
-	MaxPaymentIntervalIncrease uint64
-	Message                    string
-	UnsealPrice                string // abi.TokenAmount
-}
-
-var eventSchemaType schema.Type
-
-// RecordSuccess PUTs a notification of the retrieval to
-// http://.../retrieval-event/~retrievalId~/providers/~storageProviderId. The body of the
-// PUT will look something like:
-//
-// 	{
-// 	  "cid":{"/":"bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4bhnyiu6h7pm"},
-// 	  "time":"2022-07-12T19:57:53.112375079+10:00",
-// 	  "size":2020,
-// 	  "askPrice":"3030",
-// 	  "totalPayment":"4040",
-// 	  "numPayments":2
-// 	}
-
-// RetrievalQueryStart defines the start of the process of querying all
-// storage providers that are known to have this CID
-func (er *EventRecorder) RetrievalQueryStart(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, candidateCount int) {
-	evt := event{
-		InstanceId:     er.instanceId,
-		Stage:          "start",
-		Cid:            requestedCid,
-		Time:           timestamp.Format(time.RFC3339Nano),
-		CandidateCount: &candidateCount,
-	}
-
-	er.recordEvent("RetrievalQueryStart", retrievalId, true, "", evt)
-}
-
-// RetrievalQueryProgress events occur during the query process, stages
+// RetrievalQueryProgress events occur during the query process, events
 // include: connect and query-ask
-func (er *EventRecorder) RetrievalQueryProgress(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
-	evt := event{
-		InstanceId: er.instanceId,
-		Stage:      string(stage),
-		Cid:        requestedCid,
-		Time:       time.Now().Format(time.RFC3339Nano),
-	}
-
-	er.recordEvent("RetrievalQueryProgress", retrievalId, true, storageProviderId, evt)
+func (er *EventRecorder) RetrievalQueryProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, event rep.RetrievalEventCode) {
+	evt := er.newEventReport(retrievalId, retrievalCid, storageProviderId, rep.QueryPhase, phaseStartTime, event, eventTime)
+	er.recordEvent("RetrievalQueryProgress", evt)
 }
 
 // RetrievalQueryFailure events occur on the failure of querying a storage
 // provider. A query will result in either a RetrievalQueryFailure or
 // a RetrievalQuerySuccess event.
-func (er *EventRecorder) RetrievalQueryFailure(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, retrievalError error) {
-	es := retrievalError.Error()
-	evt := event{
-		InstanceId: er.instanceId,
-		Stage:      string(rep.RetrievalEventFailure),
-		Cid:        requestedCid,
-		Time:       time.Now().Format(time.RFC3339Nano),
-		Error:      &es,
-	}
-	er.recordEvent("RetrievalQueryFailure", retrievalId, true, storageProviderId, evt)
+func (er *EventRecorder) RetrievalQueryFailure(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, errorString string) {
+	evt := er.newEventReport(retrievalId, retrievalCid, storageProviderId, rep.QueryPhase, phaseStartTime, rep.RetrievalEventFailure, eventTime)
+	evt.EventDetails = &eventDetailsError{errorString}
+	er.recordEvent("RetrievalQueryFailure", evt)
 }
 
-// RetrievalQueryFailure events occur on successfully querying a storage
+// RetrievalQuerySuccess events occur on successfully querying a storage
 // provider. A query will result in either a RetrievalQueryFailure or
 // a RetrievalQuerySuccess event.
-func (er *EventRecorder) RetrievalQuerySuccess(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse) {
-	eqs := &eventQueryResponse{
-		Status:                     uint64(queryResponse.Status),
-		PieceCIDFound:              uint64(queryResponse.PieceCIDFound),
-		Size:                       queryResponse.Size,
-		PaymentAddress:             queryResponse.PaymentAddress.String(),
-		MinPricePerByte:            queryResponse.MinPricePerByte.String(),
-		MaxPaymentInterval:         queryResponse.MaxPaymentInterval,
-		MaxPaymentIntervalIncrease: queryResponse.MaxPaymentIntervalIncrease,
-		Message:                    queryResponse.Message,
-		UnsealPrice:                queryResponse.UnsealPrice.String(),
-	}
-	evt := event{
-		InstanceId:    er.instanceId,
-		Stage:         string(rep.RetrievalEventSuccess),
-		Cid:           requestedCid,
-		Time:          time.Now().Format(time.RFC3339Nano),
-		QueryResponse: eqs,
-	}
-
-	er.recordEvent("RetrievalQuerySuccess", retrievalId, false, storageProviderId, evt)
-}
-
-// RetrievalStart events are fired at the beginning of retrieval-proper, once
-// a storage provider is selected for retrieval. Note that upon failure,
-// another storage provider may be selected so multiple RetrievalStart events
-// may occur for the same retrieval.
-func (er *EventRecorder) RetrievalStart(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, rootCid cid.Cid, storageProviderId peer.ID) {
-	var rcid *cid.Cid
-	if !requestedCid.Equals(rootCid) {
-		rcid = &rootCid
-	}
-
-	evt := event{
-		InstanceId: er.instanceId,
-		Stage:      "start",
-		Cid:        requestedCid,
-		RootCid:    rcid,
-		Time:       timestamp.Format(time.RFC3339Nano),
-	}
-
-	er.recordEvent("RetrievalStart", retrievalId, false, storageProviderId, evt)
+func (er *EventRecorder) RetrievalQuerySuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse) {
+	evt := er.newEventReport(retrievalId, retrievalCid, storageProviderId, rep.QueryPhase, phaseStartTime, rep.RetrievalEventQueryAsk, eventTime)
+	evt.EventDetails = &queryResponse
+	er.recordEvent("RetrievalQuerySuccess", evt)
 }
 
 // RetrievalProgress events occur during the process of a retrieval. The
 // Success and failure progress event types are not reported here, but are
 // signalled via RetrievalSuccess or RetrievalFailure.
-func (er *EventRecorder) RetrievalProgress(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
-	evt := event{
-		InstanceId: er.instanceId,
-		Stage:      string(stage),
-		Cid:        requestedCid,
-		Time:       time.Now().Format(time.RFC3339Nano),
-	}
-
-	er.recordEvent("RetrievalProgress", retrievalId, false, storageProviderId, evt)
+func (er *EventRecorder) RetrievalProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, event rep.RetrievalEventCode) {
+	evt := er.newEventReport(retrievalId, retrievalCid, storageProviderId, rep.RetrievalPhase, phaseStartTime, event, eventTime)
+	er.recordEvent("RetrievalProgress", evt)
 }
 
 // RetrievalSuccess events occur on the success of a retrieval. A retrieval
 // will result in either a RetrievalQueryFailure or a RetrievalQuerySuccess
 // event.
-func (er *EventRecorder) RetrievalSuccess(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, retrievalStats filclient.RetrievalStats) {
-	ers := &eventRetrievalSuccess{
-		Size:         retrievalStats.Size,
-		AskPrice:     retrievalStats.AskPrice.String(),
-		TotalPayment: retrievalStats.TotalPayment.String(),
-		NumPayments:  uint(retrievalStats.NumPayments),
-	}
-	evt := event{
-		InstanceId: er.instanceId,
-		Stage:      string(rep.RetrievalEventSuccess),
-		Cid:        requestedCid,
-		Time:       time.Now().Format(time.RFC3339Nano),
-		Success:    ers,
-	}
-
-	er.recordEvent("RetrievalSuccess", retrievalId, false, storageProviderId, evt)
+func (er *EventRecorder) RetrievalSuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, retrievedSize uint64) {
+	evt := er.newEventReport(retrievalId, retrievalCid, storageProviderId, rep.RetrievalPhase, phaseStartTime, rep.RetrievalEventSuccess, eventTime)
+	evt.EventDetails = &eventDetailsSuccess{retrievedSize}
+	er.recordEvent("RetrievalSuccess", evt)
 }
 
 // RetrievalFailure events occur on the failure of a retrieval. A retrieval
 // will result in either a RetrievalQueryFailure or a RetrievalQuerySuccess
 // event.
-func (er *EventRecorder) RetrievalFailure(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, retrievalError error) {
-	es := retrievalError.Error()
-	evt := event{
-		InstanceId: er.instanceId,
-		Stage:      string(rep.RetrievalEventFailure),
-		Cid:        requestedCid,
-		Time:       time.Now().Format(time.RFC3339Nano),
-		Error:      &es,
-	}
-	er.recordEvent("RetrievalFailure", retrievalId, false, storageProviderId, evt)
+func (er *EventRecorder) RetrievalFailure(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, errorString string) {
+	evt := er.newEventReport(retrievalId, retrievalCid, storageProviderId, rep.RetrievalPhase, phaseStartTime, rep.RetrievalEventFailure, eventTime)
+	evt.EventDetails = &eventDetailsError{errorString}
+	er.recordEvent("RetrievalFailure", evt)
 }
 
-func (er *EventRecorder) recordEvent(eventSource string, retrievalId uuid.UUID, queryMode bool, storageProviderId peer.ID, evt event) {
-	// https://.../retrieval-event/~uuid~/providers/~peerID~
-	// or
-	// https://.../query-event/~uuid~
-	// or
-	// https://.../query-event/~uuid~/providers/~peerID~
-	eventType := "retrieval"
-	if queryMode {
-		eventType = "query"
+func (er *EventRecorder) recordEvent(eventSource string, evt eventReport) {
+	byts, err := json.Marshal(evt)
+	if err != nil {
+		log.Errorf("Failed to JSONify and encode event [%s]: %w", eventSource, err.Error())
+		return
 	}
-	prov := ""
-	if storageProviderId != "" {
-		prov = fmt.Sprintf("/providers/%s", storageProviderId.String())
-	}
-	url := fmt.Sprintf("%s/%s-event/%s%s", er.endpointURL, eventType, retrievalId.String(), prov)
 
-	node := bindnode.Wrap(&evt, eventSchemaType)
-	byts, err := ipld.Encode(node.Representation(), dagjson.Encode)
+	req, err := http.NewRequest("POST", er.endpointURL, bytes.NewBufferString(string(byts)))
 	if err != nil {
-		log.Errorf("Failed to wrap and encode event [%s]: %w", eventSource, err.Error())
+		log.Errorf("Failed to create POST request [%s] for recorder [%s]: %w", eventSource, er.endpointURL, err.Error())
 		return
 	}
-	req, err := http.NewRequest("PUT", url, bytes.NewBufferString(string(byts)))
-	if err != nil {
-		log.Errorf("Failed to create PUT request [%s] for recorder [%s]: %w", eventSource, url, err.Error())
-		return
-	}
+
 	req.Header.Set("Content-Type", "application/json")
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		log.Errorf("Failed to PUT event [%s] to recorder [%s]: %w", eventSource, url, err.Error())
+		log.Errorf("Failed to POST event [%s] to recorder [%s]: %w", eventSource, er.endpointURL, err.Error())
 		return
 	}
-	defer resp.Body.Close() // error not so important at this point
-	return
-}
 
-func init() {
-	typeSystem, err := ipld.LoadSchemaBytes([]byte(eventSchema))
-	if err != nil {
-		panic(err)
-	}
-	eventSchemaType = typeSystem.TypeByName("event")
-	if eventSchemaType == nil {
-		panic(errors.New("failed to extract `event` from schema"))
-	}
-	_ = bindnode.Prototype((*event)(nil), eventSchemaType) // check for problems
+	defer resp.Body.Close() // error not so important at this point
 }

--- a/filecoin/eventrecorder/eventrecorder.go
+++ b/filecoin/eventrecorder/eventrecorder.go
@@ -1,0 +1,126 @@
+package eventrecorder
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/application-research/filclient"
+	"github.com/google/uuid"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+func NewEventRecorder(endpointURL string) *EventRecorder {
+	return &EventRecorder{endpointURL: endpointURL}
+}
+
+type EventRecorder struct {
+	endpointURL string
+}
+
+type event struct {
+	Cid          cid.Cid   `json:"cid"`               // will use dag-json CID style thanks to Cid#MarshalJSON
+	RootCid      *cid.Cid  `json:"rootCid,omitempty"` // ditto ^
+	StartTime    time.Time `json:"startTime"`         // will use time.RFC3339Nano format
+	DurationMs   uint64    `json:"durationMs,omitempty"`
+	Size         uint64    `json:"size,omitempty"`
+	AskPrice     string    `json:"askPrice,omitempty"`     // big.Int as a string
+	TotalPayment string    `json:"totalPayment,omitempty"` // big.Int as a string
+	NumPayments  uint      `json:"numPayments,omitempty"`
+	Error        string    `json:"error,omitempty"`
+}
+
+func newEvent(
+	requestCid cid.Cid,
+	rootCid cid.Cid,
+	startTime time.Time,
+	retrievalStats *filclient.RetrievalStats,
+	retrievalError error,
+) event {
+
+	var rcid *cid.Cid
+	if !requestCid.Equals(rootCid) {
+		rcid = &rootCid
+	}
+
+	evt := event{
+		Cid:       requestCid,
+		RootCid:   rcid,
+		StartTime: startTime,
+	}
+	if retrievalStats != nil {
+		evt.DurationMs = uint64(retrievalStats.Duration.Milliseconds())
+		evt.Size = retrievalStats.Size
+		evt.AskPrice = retrievalStats.AskPrice.String()
+		evt.TotalPayment = retrievalStats.TotalPayment.String()
+		evt.NumPayments = uint(retrievalStats.NumPayments)
+	}
+	if retrievalError != nil {
+		evt.Error = retrievalError.Error()
+	}
+	return evt
+}
+
+// RecordSuccess PUTs a notification of the retrieval to
+// http://.../retrieval-event/~retrievalId~/providers/~minerId. The body of the
+// PUT will look something like:
+//
+// 	{
+// 	  "cid":{"/":"bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4bhnyiu6h7pm"},
+// 	  "startTime":"2022-07-12T19:57:53.112375079+10:00",
+// 	  "size":2020,
+// 	  "askPrice":"3030",
+// 	  "totalPayment":"4040",
+// 	  "numPayments":2
+// 	}
+func (er *EventRecorder) RecordSuccess(
+	retrievalId uuid.UUID,
+	cid cid.Cid,
+	rootCid cid.Cid,
+	startTime time.Time,
+	retrievalStats *filclient.RetrievalStats) error {
+
+	return er.recordEvent(retrievalId, retrievalStats.Peer, newEvent(cid, rootCid, startTime, retrievalStats, nil))
+}
+
+// RecordFailure PUTs a notification of the retrieval failure to
+// http://.../retrieval-event/~retrievalId~/providers/~minerId. In this case,
+// most of the body is omitted but an "error" field is present with the error
+// message.
+func (er *EventRecorder) RecordFailure(
+	retrievalId uuid.UUID,
+	minerId peer.ID,
+	cid cid.Cid,
+	rootCid cid.Cid,
+	startTime time.Time,
+	retrievalError error) error {
+
+	return er.recordEvent(retrievalId, minerId, newEvent(cid, rootCid, startTime, nil, retrievalError))
+}
+
+func (er *EventRecorder) recordEvent(retrievalId uuid.UUID, minerId peer.ID, evt event) error {
+	// https://.../event/~uuid~/providers/~peerID
+	url := fmt.Sprintf("%s/retrieval-event/%s/providers/%s", er.endpointURL, retrievalId.String(), minerId.String())
+
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(evt)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("PUT", url, &buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	_ = resp.Body.Close() // error not so important at this point
+	return nil
+}

--- a/filecoin/eventrecorder/eventrecorder.go
+++ b/filecoin/eventrecorder/eventrecorder.go
@@ -2,17 +2,18 @@ package eventrecorder
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/application-research/filclient"
-	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
 	"github.com/ipld/go-ipld-prime/node/bindnode"
-	bnregistry "github.com/ipld/go-ipld-prime/node/bindnode/registry"
+	"github.com/ipld/go-ipld-prime/schema"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
@@ -25,57 +26,32 @@ type EventRecorder struct {
 }
 
 var eventSchema string = `
-type Event struct {
-	cid                   &Any
-	rootCid      optional &Any
+type event struct {
+	cid                   Link
+	rootCid      optional Link
 	startTime             String
 	durationMs   optional Int
 	size         optional Int
 	askPrice     optional String
-	totalPayment optional Int
+	totalPayment optional String
 	numPayments  optional Int
 	error        optional String
 }
 `
 
 type event struct {
-	Cid          cid.Cid         `json:"cid"`               // will use dag-json CID style thanks to Cid#MarshalJSON
-	RootCid      *cid.Cid        `json:"rootCid,omitempty"` // ditto ^
-	StartTime    time.Time       `json:"startTime"`         // will use time.RFC3339Nano format
-	DurationMs   uint64          `json:"durationMs,omitempty"`
-	Size         uint64          `json:"size,omitempty"`
-	AskPrice     abi.TokenAmount `json:"askPrice,omitempty"`
-	TotalPayment abi.TokenAmount `json:"totalPayment,omitempty"`
-	NumPayments  uint            `json:"numPayments,omitempty"`
-	Error        string          `json:"error,omitempty"`
+	Cid          cid.Cid  // will use dag-json CID style thanks to Cid#MarshalJSON
+	RootCid      *cid.Cid // ditto ^
+	StartTime    string   // time.RFC3339Nano format
+	DurationMs   *uint64
+	Size         *uint64
+	AskPrice     *string // abi.TokenAmount / big.Int
+	TotalPayment *string // abi.TokenAmount / big.Int
+	NumPayments  *uint
+	Error        *string
 }
 
-var bindnodeRegistry bnregistry.BindnodeRegistry
-var timeConverter bindnode.Option = bindnode.TypedStringConverter(
-	(*time.Time)(nil),
-	func(string) (interface{}, error) {
-		panic("conversion from String to time.Time not supported")
-	},
-	func(ti interface{}) (string, error) {
-		return ti.(*time.Time).Format(time.RFC3339Nano), nil
-	},
-)
-var tokenAmountConverter bindnode.Option = bindnode.TypedStringConverter(
-	(*abi.TokenAmount)(nil),
-	func(string) (interface{}, error) {
-		panic("conversion from String to abi.TokenAmount not supported")
-	},
-	func(tai interface{}) (string, error) {
-		return tai.(*abi.TokenAmount).String(), nil
-	},
-)
-
-func init() {
-	bindnodeRegistry = bnregistry.NewRegistry()
-	if err := bindnodeRegistry.RegisterType((*event)(nil), eventSchema, "event"); err != nil {
-		panic(err)
-	}
-}
+var eventType schema.Type
 
 func newEvent(
 	requestCid cid.Cid,
@@ -93,17 +69,22 @@ func newEvent(
 	evt := event{
 		Cid:       requestCid,
 		RootCid:   rcid,
-		StartTime: startTime,
+		StartTime: startTime.Format(time.RFC3339Nano),
 	}
 	if retrievalStats != nil {
-		evt.DurationMs = uint64(retrievalStats.Duration.Milliseconds())
-		evt.Size = retrievalStats.Size
-		evt.AskPrice = retrievalStats.AskPrice
-		evt.TotalPayment = retrievalStats.TotalPayment
-		evt.NumPayments = uint(retrievalStats.NumPayments)
+		dms := uint64(retrievalStats.Duration.Milliseconds())
+		evt.DurationMs = &dms
+		evt.Size = &retrievalStats.Size
+		ap := retrievalStats.AskPrice.String()
+		evt.AskPrice = &ap
+		tp := retrievalStats.TotalPayment.String()
+		evt.TotalPayment = &tp
+		np := uint(retrievalStats.NumPayments)
+		evt.NumPayments = &np
 	}
 	if retrievalError != nil {
-		evt.Error = retrievalError.Error()
+		es := retrievalError.Error()
+		evt.Error = &es
 	}
 	return evt
 }
@@ -149,7 +130,8 @@ func (er *EventRecorder) recordEvent(retrievalId uuid.UUID, minerId peer.ID, evt
 	// https://.../event/~uuid~/providers/~peerID
 	url := fmt.Sprintf("%s/retrieval-event/%s/providers/%s", er.endpointURL, retrievalId.String(), minerId.String())
 
-	byts, err := bindnodeRegistry.TypeToBytes(&evt, dagjson.Encode)
+	node := bindnode.Wrap(&evt, eventType)
+	byts, err := ipld.Encode(node.Representation(), dagjson.Encode)
 	if err != nil {
 		return err
 	}
@@ -166,4 +148,16 @@ func (er *EventRecorder) recordEvent(retrievalId uuid.UUID, minerId peer.ID, evt
 	}
 	_ = resp.Body.Close() // error not so important at this point
 	return nil
+}
+
+func init() {
+	typeSystem, err := ipld.LoadSchemaBytes([]byte(eventSchema))
+	if err != nil {
+		panic(err)
+	}
+	eventType = typeSystem.TypeByName("event")
+	if eventType == nil {
+		panic(errors.New("failed to extract `event` from schema"))
+	}
+	_ = bindnode.Prototype((*event)(nil), eventType) // check for problems
 }

--- a/filecoin/eventrecorder/eventrecorder_test.go
+++ b/filecoin/eventrecorder/eventrecorder_test.go
@@ -42,7 +42,7 @@ func TestEventRecorder_Success(t *testing.T) {
 	id, err := uuid.NewRandom()
 	qt.Assert(t, err, qt.IsNil)
 	storageProviderId := peer.NewPeerRecord().PeerID
-	stats := &filclient.RetrievalStats{
+	stats := filclient.RetrievalStats{
 		Peer:         storageProviderId,
 		Duration:     time.Duration(1010),
 		Size:         2020,
@@ -50,7 +50,7 @@ func TestEventRecorder_Success(t *testing.T) {
 		TotalPayment: big.NewInt(4040),
 		NumPayments:  2,
 	}
-	qt.Assert(t, er.RecordSuccess(id, testCid1, storageProviderId, stats), qt.IsNil)
+	er.RetrievalSuccess(id, time.Now(), testCid1, storageProviderId, stats)
 
 	qt.Assert(t, req, qt.IsNotNil)
 
@@ -108,7 +108,7 @@ func TestEventRecorder_Progress(t *testing.T) {
 	id, err := uuid.NewRandom()
 	qt.Assert(t, err, qt.IsNil)
 	storageProviderId := peer.NewPeerRecord().PeerID
-	qt.Assert(t, er.RecordProgress(id, testCid1, storageProviderId, rep.RetrievalEventFirstByte), qt.IsNil)
+	er.RetrievalProgress(id, time.Now(), testCid1, storageProviderId, rep.RetrievalEventFirstByte)
 
 	qt.Assert(t, req, qt.IsNotNil)
 
@@ -163,7 +163,7 @@ func TestEventRecorder_Start(t *testing.T) {
 			qt.Assert(t, err, qt.IsNil)
 			storageProviderId := peer.NewPeerRecord().PeerID
 			startTime := time.Now().Add(time.Duration(-500))
-			qt.Assert(t, er.RecordStart(id, testCid1, rootCid, storageProviderId, startTime), qt.IsNil)
+			er.RetrievalStart(id, startTime, testCid1, rootCid, storageProviderId)
 
 			qt.Assert(t, req, qt.IsNotNil)
 
@@ -220,7 +220,7 @@ func TestEventRecorder_Failure(t *testing.T) {
 	storageProviderId := peer.NewPeerRecord().PeerID
 	err = errors.New("some error message here")
 
-	qt.Assert(t, er.RecordFailure(id, testCid1, storageProviderId, err), qt.IsNil)
+	er.RetrievalFailure(id, time.Now(), testCid1, storageProviderId, err)
 
 	// expect something like this:
 	// {

--- a/filecoin/eventrecorder/eventrecorder_test.go
+++ b/filecoin/eventrecorder/eventrecorder_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/application-research/autoretrieve/filecoin/eventrecorder"
 	"github.com/application-research/filclient"
+	"github.com/application-research/filclient/rep"
 	"github.com/filecoin-project/go-state-types/big"
 	qt "github.com/frankban/quicktest"
 	"github.com/google/uuid"
@@ -27,6 +28,124 @@ var testCid1 cid.Cid = mustCid("bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4
 var testCid2 cid.Cid = mustCid("bafyrgqhai26anf3i7pips7q22coa4sz2fr4gk4q4sqdtymvvjyginfzaqewveaeqdh524nsktaq43j65v22xxrybrtertmcfxufdam3da3hbk")
 
 func TestEventRecorder_Success(t *testing.T) {
+	var req datamodel.Node
+	var path string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		req, err = ipld.DecodeStreaming(r.Body, dagjson.Decode)
+		qt.Assert(t, err, qt.IsNil)
+		path = r.URL.Path
+	}))
+	defer ts.Close()
+
+	er := eventrecorder.NewEventRecorder("test-instance", ts.URL)
+	id, err := uuid.NewRandom()
+	qt.Assert(t, err, qt.IsNil)
+	storageProviderId := peer.NewPeerRecord().PeerID
+	stats := &filclient.RetrievalStats{
+		Peer:         storageProviderId,
+		Duration:     time.Duration(1010),
+		Size:         2020,
+		AskPrice:     big.NewInt(3030),
+		TotalPayment: big.NewInt(4040),
+		NumPayments:  2,
+	}
+	qt.Assert(t, er.RecordSuccess(id, testCid1, storageProviderId, stats), qt.IsNil)
+
+	qt.Assert(t, req, qt.IsNotNil)
+
+	pathSegments := strings.Split(path, "/")
+	qt.Assert(t, pathSegments, qt.DeepEquals, []string{"", "retrieval-event", id.String(), "providers", storageProviderId.String()})
+
+	timeNode, err := req.LookupByString("time")
+	qt.Assert(t, err, qt.IsNil)
+	timeStr, err := timeNode.AsString()
+	qt.Assert(t, err, qt.IsNil)
+
+	// expect something like this:
+	// {
+	// 	"askPrice":"0",
+	// 	"cid":{"/":"bafkreih65ouyvwap3nx2iv5ff7t6aij45zimnxld7ynbfy25koagya5nyi"},
+	// 	"instanceId":"test-instance",
+	// 	"numPayments":0,
+	// 	"size":262144,
+	// 	"stage":"success",
+	// 	"time":"2022-07-15T05:12:20.334653376Z",
+	// 	"totalPayment":"0"
+	// }
+
+	expectedMessage, err := qp.BuildMap(basicnode.Prototype.Any, -1, func(ma datamodel.MapAssembler) {
+		qp.MapEntry(ma, "askPrice", qp.String("3030"))
+		qp.MapEntry(ma, "cid", qp.Link(cidlink.Link{Cid: testCid1}))
+		qp.MapEntry(ma, "instanceId", qp.String("test-instance"))
+		qp.MapEntry(ma, "numPayments", qp.Int(2))
+		qp.MapEntry(ma, "size", qp.Int(2020))
+		qp.MapEntry(ma, "stage", qp.String("success"))
+		qp.MapEntry(ma, "time", qp.String(timeStr))
+		qp.MapEntry(ma, "totalPayment", qp.String("4040"))
+	})
+	qt.Assert(t, err, qt.IsNil)
+
+	equal := ipld.DeepEqual(req, expectedMessage)
+	if !equal {
+		t.Logf("\nwant: %s\n got: %s", mustDagJson(expectedMessage), mustDagJson(req))
+	}
+	qt.Assert(t, equal, qt.IsTrue)
+}
+
+func TestEventRecorder_Progress(t *testing.T) {
+	var req datamodel.Node
+	var path string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		req, err = ipld.DecodeStreaming(r.Body, dagjson.Decode)
+		qt.Assert(t, err, qt.IsNil)
+		path = r.URL.Path
+	}))
+	defer ts.Close()
+
+	er := eventrecorder.NewEventRecorder("test-instance", ts.URL)
+	id, err := uuid.NewRandom()
+	qt.Assert(t, err, qt.IsNil)
+	storageProviderId := peer.NewPeerRecord().PeerID
+	qt.Assert(t, er.RecordProgress(id, testCid1, storageProviderId, rep.RetrievalEventFirstByte), qt.IsNil)
+
+	qt.Assert(t, req, qt.IsNotNil)
+
+	pathSegments := strings.Split(path, "/")
+	qt.Assert(t, pathSegments, qt.DeepEquals, []string{"", "retrieval-event", id.String(), "providers", storageProviderId.String()})
+
+	timeNode, err := req.LookupByString("time")
+	qt.Assert(t, err, qt.IsNil)
+	timeStr, err := timeNode.AsString()
+	qt.Assert(t, err, qt.IsNil)
+
+	// expect something like this:
+	// {
+	// 	"cid":{"/":"bafkreih65ouyvwap3nx2iv5ff7t6aij45zimnxld7ynbfy25koagya5nyi"},
+	// 	"instanceId":"test-instance",
+	// 	"stage":"first-byte-received",
+	// 	"time":"2022-07-15T05:12:20.331482725Z"
+	// }
+
+	expectedMessage,
+		err := qp.BuildMap(basicnode.Prototype.Any,
+		-1, func(ma datamodel.MapAssembler) {
+			qp.MapEntry(ma, "cid", qp.Link(cidlink.Link{Cid: testCid1}))
+			qp.MapEntry(ma, "instanceId", qp.String("test-instance"))
+			qp.MapEntry(ma, "stage", qp.String("first-byte-received"))
+			qp.MapEntry(ma, "time", qp.String(timeStr))
+		})
+	qt.Assert(t, err, qt.IsNil)
+
+	equal := ipld.DeepEqual(req, expectedMessage)
+	if !equal {
+		t.Logf("\nwant: %s\n got: %s", mustDagJson(expectedMessage), mustDagJson(req))
+	}
+	qt.Assert(t, equal, qt.IsTrue)
+}
+
+func TestEventRecorder_Start(t *testing.T) {
 	runTest := func(rootCid cid.Cid) func(t *testing.T) {
 		return func(t *testing.T) {
 			var req datamodel.Node
@@ -39,47 +158,36 @@ func TestEventRecorder_Success(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			er := eventrecorder.NewEventRecorder(ts.URL)
+			er := eventrecorder.NewEventRecorder("test-instance", ts.URL)
 			id, err := uuid.NewRandom()
 			qt.Assert(t, err, qt.IsNil)
-			startTime := time.Now().Add(time.Duration(500))
-			minerId := peer.NewPeerRecord().PeerID
-			stats := &filclient.RetrievalStats{
-				Peer:         minerId,
-				Duration:     time.Duration(1010),
-				Size:         2020,
-				AskPrice:     big.NewInt(3030),
-				TotalPayment: big.NewInt(4040),
-				NumPayments:  2,
-			}
-			qt.Assert(t, er.RecordSuccess(id, testCid1, rootCid, startTime, stats), qt.IsNil)
-
-			// expect something like this:
-			// {
-			//   "cid":{"/":"bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4bhnyiu6h7pm"},
-			//   "startTime":"2022-07-12T19:57:53.112375079+10:00",
-			//   "size":2020,
-			//   "askPrice":"3030",
-			//   "totalPayment":"4040",
-			//   "numPayments":2
-			// }
+			storageProviderId := peer.NewPeerRecord().PeerID
+			startTime := time.Now().Add(time.Duration(-500))
+			qt.Assert(t, er.RecordStart(id, testCid1, rootCid, storageProviderId, startTime), qt.IsNil)
 
 			qt.Assert(t, req, qt.IsNotNil)
 
 			pathSegments := strings.Split(path, "/")
-			qt.Assert(t, pathSegments, qt.DeepEquals, []string{"", "retrieval-event", id.String(), "providers", minerId.String()})
+			qt.Assert(t, pathSegments, qt.DeepEquals, []string{"", "retrieval-event", id.String(), "providers", storageProviderId.String()})
 
-			expectedMessage, err := qp.BuildMap(basicnode.Prototype.Any, -1, func(ma datamodel.MapAssembler) {
-				qp.MapEntry(ma, "askPrice", qp.String("3030"))
+			// expect something like this:
+			// {
+			// 	"cid":{"/":"bafkreih65ouyvwap3nx2iv5ff7t6aij45zimnxld7ynbfy25koagya5nyi"},
+			// 	"rootCid":{"/":"bafyrgqhai26anf3i7pips7q22coa4sz2fr4gk4q4sqdtymvvjyginfzaqewveaeqdh524nsktaq43j65v22xxrybrtertmcfxufdam3da3hbk"},
+			// 	"instanceId":"test-instance",
+			// 	"stage":"start",
+			// 	"time":"2022-07-15T05:12:10.088756251Z"
+			// }
+
+			expectedMessage,
+				err := qp.BuildMap(basicnode.Prototype.Any, -1, func(ma datamodel.MapAssembler) {
 				qp.MapEntry(ma, "cid", qp.Link(cidlink.Link{Cid: testCid1}))
-				qp.MapEntry(ma, "durationMs", qp.Int(0))
-				qp.MapEntry(ma, "numPayments", qp.Int(2))
+				qp.MapEntry(ma, "instanceId", qp.String("test-instance"))
 				if !testCid1.Equals(rootCid) {
 					qp.MapEntry(ma, "rootCid", qp.Link(cidlink.Link{Cid: rootCid}))
 				}
-				qp.MapEntry(ma, "size", qp.Int(2020))
-				qp.MapEntry(ma, "startTime", qp.String(startTime.Format(time.RFC3339Nano)))
-				qp.MapEntry(ma, "totalPayment", qp.String("4040"))
+				qp.MapEntry(ma, "stage", qp.String("start"))
+				qp.MapEntry(ma, "time", qp.String(startTime.Format(time.RFC3339Nano)))
 			})
 			qt.Assert(t, err, qt.IsNil)
 
@@ -96,59 +204,56 @@ func TestEventRecorder_Success(t *testing.T) {
 }
 
 func TestEventRecorder_Failure(t *testing.T) {
-	runTest := func(rootCid cid.Cid) func(t *testing.T) {
-		return func(t *testing.T) {
-			var req datamodel.Node
-			var path string
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var err error
-				req, err = ipld.DecodeStreaming(r.Body, dagjson.Decode)
-				qt.Assert(t, err, qt.IsNil)
-				path = r.URL.Path
-			}))
-			defer ts.Close()
+	var req datamodel.Node
+	var path string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		req, err = ipld.DecodeStreaming(r.Body, dagjson.Decode)
+		qt.Assert(t, err, qt.IsNil)
+		path = r.URL.Path
+	}))
+	defer ts.Close()
 
-			er := eventrecorder.NewEventRecorder(ts.URL)
-			id, err := uuid.NewRandom()
-			qt.Assert(t, err, qt.IsNil)
-			minerId := peer.NewPeerRecord().PeerID
-			startTime := time.Now().Add(time.Duration(500))
-			err = errors.New("some error message here")
+	er := eventrecorder.NewEventRecorder("test-instance", ts.URL)
+	id, err := uuid.NewRandom()
+	qt.Assert(t, err, qt.IsNil)
+	storageProviderId := peer.NewPeerRecord().PeerID
+	err = errors.New("some error message here")
 
-			qt.Assert(t, er.RecordFailure(id, minerId, testCid1, rootCid, startTime, err), qt.IsNil)
+	qt.Assert(t, er.RecordFailure(id, testCid1, storageProviderId, err), qt.IsNil)
 
-			// expect something like this:
-			// {
-			//   "cid":{"/":"bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4bhnyiu6h7pm"},
-			//   "startTime":"2022-07-12T19:57:53.112375079+10:00",
-			//   "error":"some error message here",
-			// }
+	// expect something like this:
+	// {
+	//		"event":{"cid":{"/":"bafybeibk5afevfoe3bislt3minhwg52htzmgi356yyrhcvv2lnyzg5cjgi"},
+	//		"error":"retrieval failed: data transfer failed: deal rejected: miner is not accepting online retrieval deals",
+	//		"instanceId":"test-instance",
+	//		"stage":"failure","time":"2022-07-15T05:36:04.218007373Z"
+	// }
 
-			qt.Assert(t, req, qt.IsNotNil)
+	qt.Assert(t, req, qt.IsNotNil)
 
-			pathSegments := strings.Split(path, "/")
-			qt.Assert(t, pathSegments, qt.DeepEquals, []string{"", "retrieval-event", id.String(), "providers", minerId.String()})
+	pathSegments := strings.Split(path, "/")
+	qt.Assert(t, pathSegments, qt.DeepEquals, []string{"", "retrieval-event", id.String(), "providers", storageProviderId.String()})
 
-			expectedMessage, err := qp.BuildMap(basicnode.Prototype.Any, -1, func(ma datamodel.MapAssembler) {
-				qp.MapEntry(ma, "cid", qp.Link(cidlink.Link{Cid: testCid1}))
-				qp.MapEntry(ma, "error", qp.String("some error message here"))
-				if !testCid1.Equals(rootCid) {
-					qp.MapEntry(ma, "rootCid", qp.Link(cidlink.Link{Cid: rootCid}))
-				}
-				qp.MapEntry(ma, "startTime", qp.String(startTime.Format(time.RFC3339Nano)))
-			})
-			qt.Assert(t, err, qt.IsNil)
+	timeNode, err := req.LookupByString("time")
+	qt.Assert(t, err, qt.IsNil)
+	timeStr, err := timeNode.AsString()
+	qt.Assert(t, err, qt.IsNil)
 
-			equal := ipld.DeepEqual(req, expectedMessage)
-			if !equal {
-				t.Logf("\nwant: %s\n got: %s", mustDagJson(expectedMessage), mustDagJson(req))
-			}
-			qt.Assert(t, equal, qt.IsTrue)
-		}
+	expectedMessage, err := qp.BuildMap(basicnode.Prototype.Any, -1, func(ma datamodel.MapAssembler) {
+		qp.MapEntry(ma, "cid", qp.Link(cidlink.Link{Cid: testCid1}))
+		qp.MapEntry(ma, "error", qp.String("some error message here"))
+		qp.MapEntry(ma, "instanceId", qp.String("test-instance"))
+		qp.MapEntry(ma, "stage", qp.String("failure"))
+		qp.MapEntry(ma, "time", qp.String(timeStr))
+	})
+	qt.Assert(t, err, qt.IsNil)
+
+	equal := ipld.DeepEqual(req, expectedMessage)
+	if !equal {
+		t.Logf("\nwant: %s\n got: %s", mustDagJson(expectedMessage), mustDagJson(req))
 	}
-
-	t.Run("same-rootcid", runTest(testCid1))
-	t.Run("different-rootcid", runTest(testCid2))
+	qt.Assert(t, equal, qt.IsTrue)
 }
 
 func mustCid(cstr string) cid.Cid {

--- a/filecoin/eventrecorder/eventrecorder_test.go
+++ b/filecoin/eventrecorder/eventrecorder_test.go
@@ -1,33 +1,29 @@
 package eventrecorder_test
 
 import (
-	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/application-research/autoretrieve/filecoin/eventrecorder"
-	"github.com/application-research/filclient"
 	"github.com/application-research/filclient/rep"
-	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-state-types/abi"
 	qt "github.com/frankban/quicktest"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
 	"github.com/ipld/go-ipld-prime/datamodel"
-	"github.com/ipld/go-ipld-prime/fluent/qp"
-	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
-	"github.com/ipld/go-ipld-prime/node/basicnode"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 var testCid1 cid.Cid = mustCid("bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4bhnyiu6h7pm")
-var testCid2 cid.Cid = mustCid("bafyrgqhai26anf3i7pips7q22coa4sz2fr4gk4q4sqdtymvvjyginfzaqewveaeqdh524nsktaq43j65v22xxrybrtertmcfxufdam3da3hbk")
 
-func TestEventRecorder_Success(t *testing.T) {
+func TestEventRecorder(t *testing.T) {
 	var req datamodel.Node
 	var path string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -38,222 +34,176 @@ func TestEventRecorder_Success(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	er := eventrecorder.NewEventRecorder("test-instance", ts.URL)
-	id, err := uuid.NewRandom()
-	qt.Assert(t, err, qt.IsNil)
-	storageProviderId := peer.NewPeerRecord().PeerID
-	stats := filclient.RetrievalStats{
-		Peer:         storageProviderId,
-		Duration:     time.Duration(1010),
-		Size:         2020,
-		AskPrice:     big.NewInt(3030),
-		TotalPayment: big.NewInt(4040),
-		NumPayments:  2,
-	}
-	er.RetrievalSuccess(id, time.Now(), testCid1, storageProviderId, stats)
+	tests := []struct {
+		name string
+		exec func(t *testing.T, er *eventrecorder.EventRecorder, id uuid.UUID, etime, ptime time.Time, spid peer.ID)
+	}{
+		{
+			name: "QuerySuccess",
+			exec: func(t *testing.T, er *eventrecorder.EventRecorder, id uuid.UUID, etime, ptime time.Time, spid peer.ID) {
+				qr := retrievalmarket.QueryResponse{
+					Status:                     retrievalmarket.QueryResponseUnavailable,
+					Size:                       10101,
+					MinPricePerByte:            abi.NewTokenAmount(202020),
+					UnsealPrice:                abi.NewTokenAmount(0),
+					Message:                    "yo!",
+					PieceCIDFound:              1,
+					MaxPaymentInterval:         3030,
+					MaxPaymentIntervalIncrease: 99,
+					PaymentAddress:             address.TestAddress,
+				}
+				er.QuerySuccess(id, ptime, etime, testCid1, spid, qr)
 
-	qt.Assert(t, req, qt.IsNotNil)
+				qt.Assert(t, req.Length(), qt.Equals, int64(9))
+				verifyStringNode(t, req, "retrievalId", id.String())
+				verifyStringNode(t, req, "instanceId", "test-instance")
+				verifyStringNode(t, req, "cid", testCid1.String())
+				verifyStringNode(t, req, "storageProviderId", spid.String())
+				verifyStringNode(t, req, "phase", "query")
+				verifyStringNode(t, req, "phaseStartTime", ptime.Format(time.RFC3339Nano))
+				verifyStringNode(t, req, "event", "query-ask")
+				verifyStringNode(t, req, "eventTime", etime.Format(time.RFC3339Nano))
 
-	pathSegments := strings.Split(path, "/")
-	qt.Assert(t, pathSegments, qt.DeepEquals, []string{"", "retrieval-event", id.String(), "providers", storageProviderId.String()})
-
-	timeNode, err := req.LookupByString("time")
-	qt.Assert(t, err, qt.IsNil)
-	timeStr, err := timeNode.AsString()
-	qt.Assert(t, err, qt.IsNil)
-
-	// expect something like this:
-	// {
-	// 	"askPrice":"0",
-	// 	"cid":{"/":"bafkreih65ouyvwap3nx2iv5ff7t6aij45zimnxld7ynbfy25koagya5nyi"},
-	// 	"instanceId":"test-instance",
-	// 	"numPayments":0,
-	// 	"size":262144,
-	// 	"stage":"success",
-	// 	"time":"2022-07-15T05:12:20.334653376Z",
-	// 	"totalPayment":"0"
-	// }
-
-	expectedMessage, err := qp.BuildMap(basicnode.Prototype.Any, -1, func(ma datamodel.MapAssembler) {
-		qp.MapEntry(ma, "askPrice", qp.String("3030"))
-		qp.MapEntry(ma, "cid", qp.Link(cidlink.Link{Cid: testCid1}))
-		qp.MapEntry(ma, "instanceId", qp.String("test-instance"))
-		qp.MapEntry(ma, "numPayments", qp.Int(2))
-		qp.MapEntry(ma, "size", qp.Int(2020))
-		qp.MapEntry(ma, "stage", qp.String("success"))
-		qp.MapEntry(ma, "time", qp.String(timeStr))
-		qp.MapEntry(ma, "totalPayment", qp.String("4040"))
-	})
-	qt.Assert(t, err, qt.IsNil)
-
-	equal := ipld.DeepEqual(req, expectedMessage)
-	if !equal {
-		t.Logf("\nwant: %s\n got: %s", mustDagJson(expectedMessage), mustDagJson(req))
-	}
-	qt.Assert(t, equal, qt.IsTrue)
-}
-
-func TestEventRecorder_Progress(t *testing.T) {
-	var req datamodel.Node
-	var path string
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var err error
-		req, err = ipld.DecodeStreaming(r.Body, dagjson.Decode)
-		qt.Assert(t, err, qt.IsNil)
-		path = r.URL.Path
-	}))
-	defer ts.Close()
-
-	er := eventrecorder.NewEventRecorder("test-instance", ts.URL)
-	id, err := uuid.NewRandom()
-	qt.Assert(t, err, qt.IsNil)
-	storageProviderId := peer.NewPeerRecord().PeerID
-	er.RetrievalProgress(id, time.Now(), testCid1, storageProviderId, rep.RetrievalEventFirstByte)
-
-	qt.Assert(t, req, qt.IsNotNil)
-
-	pathSegments := strings.Split(path, "/")
-	qt.Assert(t, pathSegments, qt.DeepEquals, []string{"", "retrieval-event", id.String(), "providers", storageProviderId.String()})
-
-	timeNode, err := req.LookupByString("time")
-	qt.Assert(t, err, qt.IsNil)
-	timeStr, err := timeNode.AsString()
-	qt.Assert(t, err, qt.IsNil)
-
-	// expect something like this:
-	// {
-	// 	"cid":{"/":"bafkreih65ouyvwap3nx2iv5ff7t6aij45zimnxld7ynbfy25koagya5nyi"},
-	// 	"instanceId":"test-instance",
-	// 	"stage":"first-byte-received",
-	// 	"time":"2022-07-15T05:12:20.331482725Z"
-	// }
-
-	expectedMessage,
-		err := qp.BuildMap(basicnode.Prototype.Any,
-		-1, func(ma datamodel.MapAssembler) {
-			qp.MapEntry(ma, "cid", qp.Link(cidlink.Link{Cid: testCid1}))
-			qp.MapEntry(ma, "instanceId", qp.String("test-instance"))
-			qp.MapEntry(ma, "stage", qp.String("first-byte-received"))
-			qp.MapEntry(ma, "time", qp.String(timeStr))
-		})
-	qt.Assert(t, err, qt.IsNil)
-
-	equal := ipld.DeepEqual(req, expectedMessage)
-	if !equal {
-		t.Logf("\nwant: %s\n got: %s", mustDagJson(expectedMessage), mustDagJson(req))
-	}
-	qt.Assert(t, equal, qt.IsTrue)
-}
-
-func TestEventRecorder_Start(t *testing.T) {
-	runTest := func(rootCid cid.Cid) func(t *testing.T) {
-		return func(t *testing.T) {
-			var req datamodel.Node
-			var path string
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var err error
-				req, err = ipld.DecodeStreaming(r.Body, dagjson.Decode)
+				detailsNode, err := req.LookupByString("eventDetails")
 				qt.Assert(t, err, qt.IsNil)
-				path = r.URL.Path
-			}))
-			defer ts.Close()
+				qt.Assert(t, detailsNode.Length(), qt.Equals, int64(9))
+				verifyIntNode(t, detailsNode, "Status", 1)
+				verifyIntNode(t, detailsNode, "Size", 10101)
+				verifyIntNode(t, detailsNode, "MaxPaymentInterval", 3030)
+				verifyIntNode(t, detailsNode, "MaxPaymentIntervalIncrease", 99)
+				verifyIntNode(t, detailsNode, "PieceCIDFound", 1)
+				verifyStringNode(t, detailsNode, "UnsealPrice", "0")
+				verifyStringNode(t, detailsNode, "MinPricePerByte", "202020")
+				verifyStringNode(t, detailsNode, "PaymentAddress", address.TestAddress.String())
+				verifyStringNode(t, detailsNode, "Message", "yo!")
+			},
+		},
+		{
+			name: "RetrievalSuccess",
+			exec: func(t *testing.T, er *eventrecorder.EventRecorder, id uuid.UUID, etime, ptime time.Time, spid peer.ID) {
+				er.RetrievalSuccess(id, ptime, etime, testCid1, spid, uint64(2020))
 
-			er := eventrecorder.NewEventRecorder("test-instance", ts.URL)
+				qt.Assert(t, req.Length(), qt.Equals, int64(9))
+				verifyStringNode(t, req, "retrievalId", id.String())
+				verifyStringNode(t, req, "instanceId", "test-instance")
+				verifyStringNode(t, req, "cid", testCid1.String())
+				verifyStringNode(t, req, "storageProviderId", spid.String())
+				verifyStringNode(t, req, "phase", "retrieval")
+				verifyStringNode(t, req, "phaseStartTime", ptime.Format(time.RFC3339Nano))
+				verifyStringNode(t, req, "event", "success")
+				verifyStringNode(t, req, "eventTime", etime.Format(time.RFC3339Nano))
+
+				detailsNode, err := req.LookupByString("eventDetails")
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, detailsNode.Length(), qt.Equals, int64(1))
+				verifyIntNode(t, detailsNode, "receivedSize", 2020)
+			},
+		},
+		{
+			name: "QueryFailure",
+			exec: func(t *testing.T, er *eventrecorder.EventRecorder, id uuid.UUID, etime, ptime time.Time, spid peer.ID) {
+				er.QueryFailure(id, ptime, etime, testCid1, spid, "ha ha no")
+
+				qt.Assert(t, req.Length(), qt.Equals, int64(9))
+				verifyStringNode(t, req, "retrievalId", id.String())
+				verifyStringNode(t, req, "instanceId", "test-instance")
+				verifyStringNode(t, req, "cid", testCid1.String())
+				verifyStringNode(t, req, "storageProviderId", spid.String())
+				verifyStringNode(t, req, "phase", "query")
+				verifyStringNode(t, req, "phaseStartTime", ptime.Format(time.RFC3339Nano))
+				verifyStringNode(t, req, "event", "failure")
+				verifyStringNode(t, req, "eventTime", etime.Format(time.RFC3339Nano))
+
+				detailsNode, err := req.LookupByString("eventDetails")
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, detailsNode.Length(), qt.Equals, int64(1))
+				verifyStringNode(t, detailsNode, "error", "ha ha no")
+			},
+		},
+		{
+			name: "RetrievalFailure",
+			exec: func(t *testing.T, er *eventrecorder.EventRecorder, id uuid.UUID, etime, ptime time.Time, spid peer.ID) {
+				er.RetrievalFailure(id, ptime, etime, testCid1, spid, "ha ha no, silly silly")
+
+				qt.Assert(t, req.Length(), qt.Equals, int64(9))
+				verifyStringNode(t, req, "retrievalId", id.String())
+				verifyStringNode(t, req, "instanceId", "test-instance")
+				verifyStringNode(t, req, "cid", testCid1.String())
+				verifyStringNode(t, req, "storageProviderId", spid.String())
+				verifyStringNode(t, req, "phase", "retrieval")
+				verifyStringNode(t, req, "phaseStartTime", ptime.Format(time.RFC3339Nano))
+				verifyStringNode(t, req, "event", "failure")
+				verifyStringNode(t, req, "eventTime", etime.Format(time.RFC3339Nano))
+
+				detailsNode, err := req.LookupByString("eventDetails")
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, detailsNode.Length(), qt.Equals, int64(1))
+				verifyStringNode(t, detailsNode, "error", "ha ha no, silly silly")
+			},
+		},
+		{
+			name: "QueryProgress",
+			exec: func(t *testing.T, er *eventrecorder.EventRecorder, id uuid.UUID, etime, ptime time.Time, spid peer.ID) {
+				er.QueryProgress(id, ptime, etime, testCid1, spid, rep.RetrievalEventConnect)
+
+				qt.Assert(t, req.Length(), qt.Equals, int64(8))
+				verifyStringNode(t, req, "retrievalId", id.String())
+				verifyStringNode(t, req, "instanceId", "test-instance")
+				verifyStringNode(t, req, "cid", testCid1.String())
+				verifyStringNode(t, req, "storageProviderId", spid.String())
+				verifyStringNode(t, req, "phase", "query")
+				verifyStringNode(t, req, "phaseStartTime", ptime.Format(time.RFC3339Nano))
+				verifyStringNode(t, req, "event", "connect")
+				verifyStringNode(t, req, "eventTime", etime.Format(time.RFC3339Nano))
+			},
+		},
+		{
+			name: "RetrievalProgress",
+			exec: func(t *testing.T, er *eventrecorder.EventRecorder, id uuid.UUID, etime, ptime time.Time, spid peer.ID) {
+				er.RetrievalProgress(id, ptime, etime, testCid1, spid, rep.RetrievalEventFirstByte)
+
+				qt.Assert(t, req.Length(), qt.Equals, int64(8))
+				verifyStringNode(t, req, "retrievalId", id.String())
+				verifyStringNode(t, req, "instanceId", "test-instance")
+				verifyStringNode(t, req, "cid", testCid1.String())
+				verifyStringNode(t, req, "storageProviderId", spid.String())
+				verifyStringNode(t, req, "phase", "retrieval")
+				verifyStringNode(t, req, "phaseStartTime", ptime.Format(time.RFC3339Nano))
+				verifyStringNode(t, req, "event", "first-byte-received")
+				verifyStringNode(t, req, "eventTime", etime.Format(time.RFC3339Nano))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			er := eventrecorder.NewEventRecorder("test-instance", fmt.Sprintf("%s/test-path/here", ts.URL))
 			id, err := uuid.NewRandom()
 			qt.Assert(t, err, qt.IsNil)
-			storageProviderId := peer.NewPeerRecord().PeerID
-			startTime := time.Now().Add(time.Duration(-500))
-			er.RetrievalStart(id, startTime, testCid1, rootCid, storageProviderId)
-
+			etime := time.Now()
+			ptime := time.Now().Add(time.Hour * -1)
+			spid := peer.NewPeerRecord().PeerID
+			test.exec(t, er, id, etime, ptime, spid)
 			qt.Assert(t, req, qt.IsNotNil)
-
-			pathSegments := strings.Split(path, "/")
-			qt.Assert(t, pathSegments, qt.DeepEquals, []string{"", "retrieval-event", id.String(), "providers", storageProviderId.String()})
-
-			// expect something like this:
-			// {
-			// 	"cid":{"/":"bafkreih65ouyvwap3nx2iv5ff7t6aij45zimnxld7ynbfy25koagya5nyi"},
-			// 	"rootCid":{"/":"bafyrgqhai26anf3i7pips7q22coa4sz2fr4gk4q4sqdtymvvjyginfzaqewveaeqdh524nsktaq43j65v22xxrybrtertmcfxufdam3da3hbk"},
-			// 	"instanceId":"test-instance",
-			// 	"stage":"start",
-			// 	"time":"2022-07-15T05:12:10.088756251Z"
-			// }
-
-			expectedMessage,
-				err := qp.BuildMap(basicnode.Prototype.Any, -1, func(ma datamodel.MapAssembler) {
-				qp.MapEntry(ma, "cid", qp.Link(cidlink.Link{Cid: testCid1}))
-				qp.MapEntry(ma, "instanceId", qp.String("test-instance"))
-				if !testCid1.Equals(rootCid) {
-					qp.MapEntry(ma, "rootCid", qp.Link(cidlink.Link{Cid: rootCid}))
-				}
-				qp.MapEntry(ma, "stage", qp.String("start"))
-				qp.MapEntry(ma, "time", qp.String(startTime.Format(time.RFC3339Nano)))
-			})
-			qt.Assert(t, err, qt.IsNil)
-
-			equal := ipld.DeepEqual(req, expectedMessage)
-			if !equal {
-				t.Logf("\nwant: %s\n got: %s", mustDagJson(expectedMessage), mustDagJson(req))
-			}
-			qt.Assert(t, equal, qt.IsTrue)
-		}
+			qt.Assert(t, path, qt.Equals, "/test-path/here")
+		})
 	}
-
-	t.Run("same-rootcid", runTest(testCid1))
-	t.Run("different-rootcid", runTest(testCid2))
 }
 
-func TestEventRecorder_Failure(t *testing.T) {
-	var req datamodel.Node
-	var path string
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var err error
-		req, err = ipld.DecodeStreaming(r.Body, dagjson.Decode)
-		qt.Assert(t, err, qt.IsNil)
-		path = r.URL.Path
-	}))
-	defer ts.Close()
-
-	er := eventrecorder.NewEventRecorder("test-instance", ts.URL)
-	id, err := uuid.NewRandom()
+func verifyStringNode(t *testing.T, node datamodel.Node, key string, expected string) {
+	subNode, err := node.LookupByString(key)
 	qt.Assert(t, err, qt.IsNil)
-	storageProviderId := peer.NewPeerRecord().PeerID
-	err = errors.New("some error message here")
-
-	er.RetrievalFailure(id, time.Now(), testCid1, storageProviderId, err)
-
-	// expect something like this:
-	// {
-	//		"event":{"cid":{"/":"bafybeibk5afevfoe3bislt3minhwg52htzmgi356yyrhcvv2lnyzg5cjgi"},
-	//		"error":"retrieval failed: data transfer failed: deal rejected: miner is not accepting online retrieval deals",
-	//		"instanceId":"test-instance",
-	//		"stage":"failure","time":"2022-07-15T05:36:04.218007373Z"
-	// }
-
-	qt.Assert(t, req, qt.IsNotNil)
-
-	pathSegments := strings.Split(path, "/")
-	qt.Assert(t, pathSegments, qt.DeepEquals, []string{"", "retrieval-event", id.String(), "providers", storageProviderId.String()})
-
-	timeNode, err := req.LookupByString("time")
+	str, err := subNode.AsString()
 	qt.Assert(t, err, qt.IsNil)
-	timeStr, err := timeNode.AsString()
-	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, str, qt.Equals, expected)
+}
 
-	expectedMessage, err := qp.BuildMap(basicnode.Prototype.Any, -1, func(ma datamodel.MapAssembler) {
-		qp.MapEntry(ma, "cid", qp.Link(cidlink.Link{Cid: testCid1}))
-		qp.MapEntry(ma, "error", qp.String("some error message here"))
-		qp.MapEntry(ma, "instanceId", qp.String("test-instance"))
-		qp.MapEntry(ma, "stage", qp.String("failure"))
-		qp.MapEntry(ma, "time", qp.String(timeStr))
-	})
+func verifyIntNode(t *testing.T, node datamodel.Node, key string, expected int64) {
+	subNode, err := node.LookupByString(key)
 	qt.Assert(t, err, qt.IsNil)
-
-	equal := ipld.DeepEqual(req, expectedMessage)
-	if !equal {
-		t.Logf("\nwant: %s\n got: %s", mustDagJson(expectedMessage), mustDagJson(req))
-	}
-	qt.Assert(t, equal, qt.IsTrue)
+	ii, err := subNode.AsInt()
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, ii, qt.Equals, expected)
 }
 
 func mustCid(cstr string) cid.Cid {
@@ -262,12 +212,4 @@ func mustCid(cstr string) cid.Cid {
 		panic(err)
 	}
 	return c
-}
-
-func mustDagJson(node datamodel.Node) string {
-	byts, err := ipld.Encode(node, dagjson.Encode)
-	if err != nil {
-		panic(err)
-	}
-	return string(byts)
 }

--- a/filecoin/eventrecorder/eventrecorder_test.go
+++ b/filecoin/eventrecorder/eventrecorder_test.go
@@ -1,0 +1,207 @@
+package eventrecorder_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/application-research/autoretrieve/filecoin/eventrecorder"
+	"github.com/application-research/filclient"
+	"github.com/filecoin-project/go-state-types/big"
+	qt "github.com/frankban/quicktest"
+	"github.com/google/uuid"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagjson"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+var testCid1 cid.Cid = mustCid("bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4bhnyiu6h7pm")
+var testCid2 cid.Cid = mustCid("bafyrgqhai26anf3i7pips7q22coa4sz2fr4gk4q4sqdtymvvjyginfzaqewveaeqdh524nsktaq43j65v22xxrybrtertmcfxufdam3da3hbk")
+
+func TestEventRecorder_Success(t *testing.T) {
+	runTest := func(rootCid cid.Cid) func(t *testing.T) {
+		return func(t *testing.T) {
+			var req datamodel.Node
+			var path string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var err error
+				req, err = ipld.DecodeStreaming(r.Body, dagjson.Decode)
+				qt.Assert(t, err, qt.IsNil)
+				path = r.URL.Path
+			}))
+			defer ts.Close()
+
+			er := eventrecorder.NewEventRecorder(ts.URL)
+			id, err := uuid.NewRandom()
+			qt.Assert(t, err, qt.IsNil)
+			startTime := time.Now().Add(time.Duration(500))
+			minerId := peer.NewPeerRecord().PeerID
+			stats := &filclient.RetrievalStats{
+				Peer:         minerId,
+				Duration:     time.Duration(1010),
+				Size:         2020,
+				AskPrice:     big.NewInt(3030),
+				TotalPayment: big.NewInt(4040),
+				NumPayments:  2,
+			}
+			qt.Assert(t, er.RecordSuccess(id, testCid1, rootCid, startTime, stats), qt.IsNil)
+
+			// expect something like this:
+			// {
+			//   "cid":{"/":"bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4bhnyiu6h7pm"},
+			//   "startTime":"2022-07-12T19:57:53.112375079+10:00",
+			//   "size":2020,
+			//   "askPrice":"3030",
+			//   "totalPayment":"4040",
+			//   "numPayments":2
+			// }
+
+			qt.Assert(t, req, qt.IsNotNil)
+
+			pathSegments := strings.Split(path, "/")
+			qt.Assert(t, pathSegments, qt.DeepEquals, []string{"", "retrieval-event", id.String(), "providers", minerId.String()})
+
+			gotCidNode, err := req.LookupByString("cid")
+			qt.Assert(t, err, qt.IsNil)
+			gotCid, err := gotCidNode.AsLink()
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, gotCid.String(), qt.Equals, testCid1.String())
+
+			gotRootCidNode, err := req.LookupByString("rootCid")
+			if rootCid.Equals(testCid1) {
+				qt.Assert(t, err, qt.IsNotNil)
+			} else {
+				qt.Assert(t, err, qt.IsNil)
+				gotRootCid, err := gotRootCidNode.AsLink()
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, gotRootCid.String(), qt.Equals, rootCid.String())
+			}
+
+			gotStartTimeNode, err := req.LookupByString("startTime")
+			qt.Assert(t, err, qt.IsNil)
+			gotStartTime, err := gotStartTimeNode.AsString()
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, gotStartTime, qt.Equals, startTime.Format(time.RFC3339Nano))
+
+			gotSizeNode, err := req.LookupByString("size")
+			qt.Assert(t, err, qt.IsNil)
+			gotSize, err := gotSizeNode.AsInt()
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, gotSize, qt.Equals, int64(2020))
+
+			gotAskPriceNode, err := req.LookupByString("askPrice")
+			qt.Assert(t, err, qt.IsNil)
+			gotAskPrice, err := gotAskPriceNode.AsString()
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, gotAskPrice, qt.Equals, "3030")
+
+			gotTotalPaymentNode, err := req.LookupByString("totalPayment")
+			qt.Assert(t, err, qt.IsNil)
+			gotTotalPayment, err := gotTotalPaymentNode.AsString()
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, gotTotalPayment, qt.Equals, "4040")
+
+			gotNumPaymentsNode, err := req.LookupByString("numPayments")
+			qt.Assert(t, err, qt.IsNil)
+			gotNumPayments, err := gotNumPaymentsNode.AsInt()
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, gotNumPayments, qt.Equals, int64(2))
+		}
+	}
+
+	t.Run("same-rootcid", runTest(testCid1))
+	t.Run("different-rootcid", runTest(testCid2))
+}
+
+func TestEventRecorder_Failure(t *testing.T) {
+	runTest := func(rootCid cid.Cid) func(t *testing.T) {
+		return func(t *testing.T) {
+			var req datamodel.Node
+			var path string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var err error
+				req, err = ipld.DecodeStreaming(r.Body, dagjson.Decode)
+				qt.Assert(t, err, qt.IsNil)
+				path = r.URL.Path
+			}))
+			defer ts.Close()
+
+			er := eventrecorder.NewEventRecorder(ts.URL)
+			id, err := uuid.NewRandom()
+			qt.Assert(t, err, qt.IsNil)
+			minerId := peer.NewPeerRecord().PeerID
+			startTime := time.Now().Add(time.Duration(500))
+			err = errors.New("some error message here")
+
+			qt.Assert(t, er.RecordFailure(id, minerId, testCid1, rootCid, startTime, err), qt.IsNil)
+
+			// expect something like this:
+			// {
+			//   "cid":{"/":"bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4bhnyiu6h7pm"},
+			//   "startTime":"2022-07-12T19:57:53.112375079+10:00",
+			//   "error":"some error message here",
+			// }
+
+			qt.Assert(t, req, qt.IsNotNil)
+
+			pathSegments := strings.Split(path, "/")
+			qt.Assert(t, pathSegments, qt.DeepEquals, []string{"", "retrieval-event", id.String(), "providers", minerId.String()})
+
+			gotCidNode, err := req.LookupByString("cid")
+			qt.Assert(t, err, qt.IsNil)
+			gotCid, err := gotCidNode.AsLink()
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, gotCid.String(), qt.Equals, testCid1.String())
+
+			gotRootCidNode, err := req.LookupByString("rootCid")
+			if rootCid.Equals(testCid1) {
+				qt.Assert(t, err, qt.IsNotNil)
+			} else {
+				qt.Assert(t, err, qt.IsNil)
+				gotRootCid, err := gotRootCidNode.AsLink()
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, gotRootCid.String(), qt.Equals, rootCid.String())
+			}
+
+			gotStartTimeNode, err := req.LookupByString("startTime")
+			qt.Assert(t, err, qt.IsNil)
+			gotStartTime, err := gotStartTimeNode.AsString()
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, gotStartTime, qt.Equals, startTime.Format(time.RFC3339Nano))
+
+			getErrorNode, err := req.LookupByString("error")
+			qt.Assert(t, err, qt.IsNil)
+			getError, err := getErrorNode.AsString()
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, getError, qt.Equals, "some error message here")
+
+			_, err = req.LookupByString("size")
+			qt.Assert(t, err, qt.IsNotNil)
+
+			_, err = req.LookupByString("askPrice")
+			qt.Assert(t, err, qt.IsNotNil)
+
+			_, err = req.LookupByString("totalPayment")
+			qt.Assert(t, err, qt.IsNotNil)
+
+			_, err = req.LookupByString("numPayments")
+			qt.Assert(t, err, qt.IsNotNil)
+		}
+	}
+
+	t.Run("same-rootcid", runTest(testCid1))
+	t.Run("different-rootcid", runTest(testCid2))
+}
+
+func mustCid(cstr string) cid.Cid {
+	c, err := cid.Decode(cstr)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}

--- a/filecoin/eventrecorder/eventrecorder_test.go
+++ b/filecoin/eventrecorder/eventrecorder_test.go
@@ -61,7 +61,7 @@ func TestEventRecorder(t *testing.T) {
 				verifyStringNode(t, req, "storageProviderId", spid.String())
 				verifyStringNode(t, req, "phase", "query")
 				verifyStringNode(t, req, "phaseStartTime", ptime.Format(time.RFC3339Nano))
-				verifyStringNode(t, req, "event", "query-ask")
+				verifyStringNode(t, req, "event", "query-asked")
 				verifyStringNode(t, req, "eventTime", etime.Format(time.RFC3339Nano))
 
 				detailsNode, err := req.LookupByString("eventDetails")
@@ -153,7 +153,7 @@ func TestEventRecorder(t *testing.T) {
 				verifyStringNode(t, req, "storageProviderId", spid.String())
 				verifyStringNode(t, req, "phase", "query")
 				verifyStringNode(t, req, "phaseStartTime", ptime.Format(time.RFC3339Nano))
-				verifyStringNode(t, req, "event", "connect")
+				verifyStringNode(t, req, "event", "connected")
 				verifyStringNode(t, req, "eventTime", etime.Format(time.RFC3339Nano))
 			},
 		},

--- a/filecoin/eventrecorder/filelogserver/filelogserver.go
+++ b/filecoin/eventrecorder/filelogserver/filelogserver.go
@@ -10,21 +10,14 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
-	"strings"
 
-	"github.com/google/uuid"
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/ipld/go-ipld-prime"
-	"github.com/ipld/go-ipld-prime/codec/dagjson"
-	"github.com/ipld/go-ipld-prime/datamodel"
-	"github.com/ipld/go-ipld-prime/fluent/qp"
-	"github.com/ipld/go-ipld-prime/node/basicnode"
-	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 var log = logging.Logger("filelogserver")
@@ -40,81 +33,32 @@ func main() {
 	}
 	log.Infof("Writing to file %s", *output)
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/retrieval-events", func(w http.ResponseWriter, r *http.Request) {
 		if r.Body == nil {
 			http.Error(w, "Expected request body", http.StatusBadRequest)
 			return
 		}
 
-		// validate path
-		urlSegments := strings.Split(r.URL.Path, "/")
-		errAction := func() {
-			log.Errorf("Malformed URL, expected /(retrieval|query)-event/~uuid~[/providers/~peerid~], got: %s", r.URL.Path)
-			http.Error(w, "Malformed URL, expected /(retrieval|query)-event/~uuid~[/providers/~peerid~]", http.StatusBadRequest)
-		}
-		switch len(urlSegments) {
-		case 3:
-			if urlSegments[1] != "query-event" {
-				errAction()
-				return
-			}
-		case 5:
-			if !(urlSegments[1] == "retrieval-event" || urlSegments[1] == "query-event") || urlSegments[3] != "providers" {
-				errAction()
-				return
-			}
-		default:
-			errAction()
-			return
-		}
-
-		retrievalId, err := uuid.Parse(urlSegments[2])
-		if err != nil {
-			log.Errorf("Malformed URL, expected /retrieval-event/~uuid~/providers/~peerid~, got bad uuid: %s", err.Error())
-			http.Error(w, "Malformed URL, expected /retrieval-event/~uuid~/providers/~peerid~", http.StatusBadRequest)
-			return
-		}
-		var peerId peer.ID
-
-		if len(urlSegments) > 3 {
-			peerId, err = peer.Decode(urlSegments[4])
-			if err != nil {
-				log.Errorf("Malformed URL, expected /(retrieval|query)-event/~uuid~/providers/~peerid~, got bad peerID: %s", err.Error())
-				http.Error(w, "Malformed URL, expected /(retrieval|query)-event/~uuid~/providers/~peerid~", http.StatusBadRequest)
-				return
-			}
-		}
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			log.Errorf("Could not decode body: %s", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		node, err := ipld.Decode(body, dagjson.Decode)
+		m := make(map[string]interface{})
+		err = json.Unmarshal(body, &m)
 		if err != nil {
 			log.Errorf("Could not decode body: %s", err.Error())
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		logNode, err := qp.BuildMap(basicnode.Prototype.Any, -1, func(ma datamodel.MapAssembler) {
-			qp.MapEntry(ma, "retrievalId", qp.String(retrievalId.String()))
-			qp.MapEntry(ma, "mode", qp.String(strings.Split(urlSegments[1], "-")[0]))
-			if peerId != "" {
-				qp.MapEntry(ma, "peerId", qp.String(peerId.String()))
-			}
-			qp.MapEntry(ma, "event", qp.Node(node))
-		})
+		reencode, err := json.Marshal(m)
 		if err != nil {
 			log.Errorf("Error building log entry: %s", err.Error())
 			return
 		}
-		logEntry, err := ipld.Encode(logNode, dagjson.Encode)
-		if err != nil {
-			log.Errorf("Error encoding log entry: %s", err.Error())
-			return
-		}
-		log.Debugf("Got: %s", string(logEntry))
-		outfile.WriteString(string(logEntry))
+		log.Debugf("Got: %s", string(reencode))
+		outfile.WriteString(string(reencode))
 		outfile.Write([]byte{'\n'})
 	})
 

--- a/filecoin/eventrecorder/filelogserver/filelogserver.go
+++ b/filecoin/eventrecorder/filelogserver/filelogserver.go
@@ -1,0 +1,99 @@
+// A simple HTTP server that receives EventRecorder events and writes them,
+// as line-delimited JSON to an output file.
+//
+// 	* Use `--port` to set the port (default: 8080)
+//
+//  * Use `--output` to set the output file path (default: output.json)
+//
+// When encoded as JSON, the original event JSON will be wrapped in a parent
+// with the "retrievalId" UUID and "peerId" peerID that come from the URL.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagjson"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/fluent/qp"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+var log = logging.Logger("filelogserver")
+
+func main() {
+	port := flag.Int("port", 8080, "set port to listen to")
+	output := flag.String("output", "output.json", "set a file to write to")
+	flag.Parse()
+
+	outfile, err := os.OpenFile(*output, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		panic(err)
+	}
+	log.Infof("Writing to file %s", *output)
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Body == nil {
+			http.Error(w, "Expected request body", http.StatusBadRequest)
+			return
+		}
+		urlSegments := strings.Split(r.URL.Path, "/")
+		if len(urlSegments) != 5 || urlSegments[1] != "retrieval-event" || urlSegments[3] != "providers" {
+			log.Errorf("Malformed URL, expected /retrieval-event/~uuid~/providers/~peerid~, got: %s", r.URL.Path)
+			http.Error(w, "Malformed URL, expected /retrieval-event/~uuid~/providers/~peerid~", http.StatusBadRequest)
+			return
+		}
+		retrievalId, err := uuid.Parse(urlSegments[2])
+		if err != nil {
+			log.Errorf("Malformed URL, expected /retrieval-event/~uuid~/providers/~peerid~, got bad uuid: %s", err.Error())
+			http.Error(w, "Malformed URL, expected /retrieval-event/~uuid~/providers/~peerid~", http.StatusBadRequest)
+			return
+		}
+		peerId, err := peer.Decode(urlSegments[4])
+		if err != nil {
+			log.Errorf("Malformed URL, expected /retrieval-event/~uuid~/providers/~peerid~, got bad peerID: %s", err.Error())
+			http.Error(w, "Malformed URL, expected /retrieval-event/~uuid~/providers/~peerid~", http.StatusBadRequest)
+			return
+		}
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Errorf("Could not decode body: %s", err.Error())
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		node, err := ipld.Decode(body, dagjson.Decode)
+		if err != nil {
+			log.Errorf("Could not decode body: %s", err.Error())
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		logNode, err := qp.BuildMap(basicnode.Prototype.Any, -1, func(ma datamodel.MapAssembler) {
+			qp.MapEntry(ma, "retrievalId", qp.String(retrievalId.String()))
+			qp.MapEntry(ma, "peerId", qp.String(peerId.String()))
+			qp.MapEntry(ma, "event", qp.Node(node))
+		})
+		if err != nil {
+			log.Errorf("Error building log entry: %s", err.Error())
+			return
+		}
+		logEntry, err := ipld.Encode(logNode, dagjson.Encode)
+		if err != nil {
+			log.Errorf("Error encoding log entry: %s", err.Error())
+			return
+		}
+		log.Debugf("Got: %s", string(logEntry))
+		outfile.WriteString(string(logEntry))
+		outfile.Write([]byte{'\n'})
+	})
+
+	log.Infof("Listening on port %d", *port)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
+}

--- a/filecoin/retriever.go
+++ b/filecoin/retriever.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/application-research/autoretrieve/filecoin/eventrecorder"
 	"github.com/application-research/autoretrieve/metrics"
 	"github.com/application-research/filclient"
 	"github.com/application-research/filclient/rep"
@@ -67,7 +68,7 @@ type Retriever struct {
 
 	endpoint      Endpoint
 	filClient     *filclient.FilClient
-	eventRecorder EventRecorder
+	eventRecorder *eventrecorder.EventRecorder
 
 	runningRetrievals        map[cid.Cid]bool
 	activeRetrievalsPerMiner map[peer.ID]uint
@@ -86,11 +87,6 @@ type RetrievalCandidate struct {
 	RootCid   cid.Cid
 }
 
-type EventRecorder interface {
-	RecordSuccess(uuid.UUID, cid.Cid, cid.Cid, time.Time, *filclient.RetrievalStats) error
-	RecordFailure(uuid.UUID, peer.ID, cid.Cid, cid.Cid, time.Time, error) error
-}
-
 type Endpoint interface {
 	FindCandidates(context.Context, cid.Cid) ([]RetrievalCandidate, error)
 }
@@ -101,7 +97,7 @@ func NewRetriever(
 	config RetrieverConfig,
 	filClient *filclient.FilClient,
 	endpoint Endpoint,
-	eventRecorder EventRecorder,
+	eventRecorder *eventrecorder.EventRecorder,
 ) (*Retriever, error) {
 	retriever := &Retriever{
 		config:                   config,

--- a/filecoin/retriever.go
+++ b/filecoin/retriever.go
@@ -477,7 +477,7 @@ func (retriever *Retriever) OnRetrievalEvent(event rep.RetrievalEvent, state rep
 	case rep.RetrievalEventFailure:
 		if event.Phase == rep.QueryPhase {
 			retriever.activeRetrievals.QueryCandidatedFinished(retrievalCid)
-			retriever.eventManager.FireRetrievalQueryFailure(
+			retriever.eventManager.FireQueryFailure(
 				retrievalId,
 				state.PayloadCid,
 				phaseStartTime,
@@ -496,7 +496,7 @@ func (retriever *Retriever) OnRetrievalEvent(event rep.RetrievalEvent, state rep
 		}
 	case rep.RetrievalEventQueryAsk: // query-ask success
 		retriever.activeRetrievals.QueryCandidatedFinished(retrievalCid)
-		retriever.eventManager.FireRetrievalQuerySuccess(
+		retriever.eventManager.FireQuerySuccess(
 			retrievalId,
 			state.PayloadCid,
 			phaseStartTime,
@@ -514,7 +514,7 @@ func (retriever *Retriever) OnRetrievalEvent(event rep.RetrievalEvent, state rep
 		)
 	default:
 		if event.Phase == rep.QueryPhase {
-			retriever.eventManager.FireRetrievalQueryProgress(
+			retriever.eventManager.FireQueryProgress(
 				retrievalId,
 				state.PayloadCid,
 				phaseStartTime,

--- a/filecoin/retriever.go
+++ b/filecoin/retriever.go
@@ -89,6 +89,7 @@ type Endpoint interface {
 // Possible errors: ErrInitKeystoreFailed, ErrInitWalletFailed,
 // ErrInitFilClientFailed
 func NewRetriever(
+	ctx context.Context,
 	config RetrieverConfig,
 	filClient *filclient.FilClient,
 	endpoint Endpoint,
@@ -97,7 +98,7 @@ func NewRetriever(
 		config:           config,
 		endpoint:         endpoint,
 		filClient:        filClient,
-		eventManager:     NewEventManager(),
+		eventManager:     NewEventManager(ctx),
 		activeRetrievals: NewActiveRetrievalsManager(),
 		minerMonitor: newMinerMonitor(minerMonitorConfig{
 			maxFailuresBeforeSuspend: 5,

--- a/filecoin/retriever.go
+++ b/filecoin/retriever.go
@@ -507,8 +507,17 @@ func formatCid(cid cid.Cid, short bool) string {
 }
 
 // Implement rep.RetrievalSubscriber
-func (retriever *Retriever) OnRetrievalEvent(event rep.RetrievalEvent) {
-	log.Debugf("%s %s", event.Code, event.Status)
+func (retriever *Retriever) OnRetrievalEvent(event rep.RetrievalEvent, state rep.RetrievalState) {
+	log.Debugw("retrieval-event",
+		"code", event.Code,
+		"status", event.Status,
+		"storage-provider-id", state.StorageProviderID,
+		"storage-provider-address", state.StorageProviderAddr,
+		"client-address", state.ClientID,
+		"payload-cid", state.PayloadCid,
+		"piece-cid", state.PieceCid,
+		"finished-time", state.FinishedTime,
+	)
 }
 
 func (retriever *Retriever) RetrievalSubscriberId() interface{} {

--- a/filecoin/retriever.go
+++ b/filecoin/retriever.go
@@ -174,7 +174,7 @@ func (retriever *Retriever) retrieveFromBestCandidate(ctx context.Context, retri
 	// register that we have this many candidates to retrieve from, so that when we
 	// receive success or failures from that many we know the phase is completed,
 	// if zero at this point then clean-up will occur
-	retriever.activeRetrievals.RetrievalCandidateCount(retrievalCid, len(queries))
+	retriever.activeRetrievals.SetRetrievalCandidateCount(retrievalCid, len(queries))
 	if len(queries) == 0 {
 		return nil
 	}
@@ -466,7 +466,7 @@ func (retriever *Retriever) OnRetrievalEvent(event rep.RetrievalEvent, state rep
 		"finished-time", state.FinishedTime,
 	)
 
-	retrievalId, retrievalCid, phaseStartTime, has := retriever.activeRetrievals.StatusFor(state.PayloadCid, event.Phase)
+	retrievalId, retrievalCid, phaseStartTime, has := retriever.activeRetrievals.GetStatusFor(state.PayloadCid, event.Phase)
 
 	if !has {
 		log.Errorf("Received event [%s] for unexpected retrieval: payload-cid=%s, storage-provider-id=%s", event.Code, state.PayloadCid, state.StorageProviderID)

--- a/filecoin/retriever.go
+++ b/filecoin/retriever.go
@@ -256,6 +256,14 @@ func (retriever *Retriever) retrieveFromBestCandidate(ctx context.Context, cid c
 			stats.Record(ctx, metrics.RetrievalDealDuration.M(retrievalStats.Duration.Seconds()))
 			stats.Record(ctx, metrics.RetrievalDealSize.M(int64(retrievalStats.Size)))
 			stats.Record(ctx, metrics.RetrievalDealCost.M(retrievalStats.TotalPayment.Int64()))
+
+			// TODO: this is a _final_ report, we want a _start_ report before we start the retrieval and then we
+			// want to register one for each of the events that come out of filclient
+			// see `func (fc *FilClient) OnRetrievalEvent(event rep.RetrievalEvent, state rep.RetrievalState)` in
+			// filclient/filclient.go
+			// need to decide what to do with the final report for both success and failure - we could either use
+			// it coming out of the event or do it here, perhaps we have more information here? want to avoid
+			// anything racy though
 			if retriever.eventRecorder != nil {
 				if err := retriever.eventRecorder.RecordSuccess(
 					retrievalId,
@@ -263,7 +271,9 @@ func (retriever *Retriever) retrieveFromBestCandidate(ctx context.Context, cid c
 					query.candidate.RootCid,
 					startTime,
 					retrievalStats,
-					// TODO: instance name? from where?
+					// TODO: instance name:
+					// put an option in the config with a sensible default, we can update it later
+					// to something meaningful if we care, for now we're just using a placeholder
 				); err != nil {
 					log.Errorf("Failed to post event to recorder:", err)
 				}

--- a/filecoin/retrieverevents.go
+++ b/filecoin/retrieverevents.go
@@ -16,19 +16,19 @@ import (
 // retrieval process, including the process of querying available storage
 // providers to find compatible ones to attempt retrieval from.
 type RetrievalEventListener interface {
-	// RetrievalQueryProgress events occur during the query process, stages.
+	// QueryProgress events occur during the query process, stages.
 	// Currently this should just include a "connect" event.
-	RetrievalQueryProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode)
+	QueryProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode)
 
-	// RetrievalQueryFailure events occur on the failure of querying a storage
-	// provider. A query will result in either a RetrievalQueryFailure or
-	// a RetrievalQuerySuccess event.
-	RetrievalQueryFailure(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, errString string)
+	// QueryFailure events occur on the failure of querying a storage
+	// provider. A query will result in either a QueryFailure or
+	// a QuerySuccess event.
+	QueryFailure(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, errString string)
 
-	// RetrievalQueryFailure events occur on successfully querying a storage
-	// provider. A query will result in either a RetrievalQueryFailure or
-	// a RetrievalQuerySuccess event.
-	RetrievalQuerySuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse)
+	// QuerySuccess ("query-ask") events occur on successfully querying a storage
+	// provider. A query will result in either a QueryFailure or
+	// a QuerySuccess event.
+	QuerySuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse)
 
 	// RetrievalProgress events occur during the process of a retrieval. The
 	// Success and failure progress event types are not reported here, but are
@@ -36,12 +36,12 @@ type RetrievalEventListener interface {
 	RetrievalProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode)
 
 	// RetrievalSuccess events occur on the success of a retrieval. A retrieval
-	// will result in either a RetrievalQueryFailure or a RetrievalQuerySuccess
+	// will result in either a QueryFailure or a QuerySuccess
 	// event.
 	RetrievalSuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, receivedSize uint64)
 
 	// RetrievalFailure events occur on the failure of a retrieval. A retrieval
-	// will result in either a RetrievalQueryFailure or a RetrievalQuerySuccess
+	// will result in either a QueryFailure or a QuerySuccess
 	// event.
 	RetrievalFailure(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, errString string)
 }
@@ -113,24 +113,24 @@ func (em *EventManager) queueEvent(cb func(timestamp time.Time, listener Retriev
 	}
 }
 
-// FireRetrievalQueryProgress calls RetrievalQueryProgress for all listeners
-func (em *EventManager) FireRetrievalQueryProgress(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
+// FireQueryProgress calls QueryProgress for all listeners
+func (em *EventManager) FireQueryProgress(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
 	em.queueEvent(func(timestamp time.Time, listener RetrievalEventListener) {
-		listener.RetrievalQueryProgress(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, stage)
+		listener.QueryProgress(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, stage)
 	})
 }
 
-// FireRetrievalQueryFailure calls RetrievalQueryFailure for all listeners
-func (em *EventManager) FireRetrievalQueryFailure(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, errString string) {
+// FireQueryFailure calls QueryFailure for all listeners
+func (em *EventManager) FireQueryFailure(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, errString string) {
 	em.queueEvent(func(timestamp time.Time, listener RetrievalEventListener) {
-		listener.RetrievalQueryFailure(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, errString)
+		listener.QueryFailure(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, errString)
 	})
 }
 
-// FireRetrievalQuerySuccess calls RetrievalQuerySuccess for all listeners
-func (em *EventManager) FireRetrievalQuerySuccess(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse) {
+// FireQuerySuccess calls QuerySuccess ("query-ask") for all listeners
+func (em *EventManager) FireQuerySuccess(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse) {
 	em.queueEvent(func(timestamp time.Time, listener RetrievalEventListener) {
-		listener.RetrievalQuerySuccess(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, queryResponse)
+		listener.QuerySuccess(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, queryResponse)
 	})
 }
 

--- a/filecoin/retrieverevents.go
+++ b/filecoin/retrieverevents.go
@@ -45,17 +45,17 @@ type RetrievalEventListener interface {
 	RetrievalFailure(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, errString string)
 }
 
-type eventManager struct {
+type EventManager struct {
 	lk        sync.RWMutex
 	idx       int
 	listeners map[int]RetrievalEventListener
 }
 
-func newEventManager() *eventManager {
-	return &eventManager{listeners: make(map[int]RetrievalEventListener)}
+func NewEventManager() *EventManager {
+	return &EventManager{listeners: make(map[int]RetrievalEventListener)}
 }
 
-func (em *eventManager) RegisterListener(listener RetrievalEventListener) func() {
+func (em *EventManager) RegisterListener(listener RetrievalEventListener) func() {
 	em.lk.Lock()
 	defer em.lk.Unlock()
 
@@ -71,7 +71,7 @@ func (em *eventManager) RegisterListener(listener RetrievalEventListener) func()
 	}
 }
 
-func (em *eventManager) fireEvent(cb func(timestamp time.Time, listener RetrievalEventListener)) {
+func (em *EventManager) fireEvent(cb func(timestamp time.Time, listener RetrievalEventListener)) {
 	timestamp := time.Now()
 	go func() {
 		em.lk.RLock()
@@ -87,37 +87,37 @@ func (em *eventManager) fireEvent(cb func(timestamp time.Time, listener Retrieva
 	}()
 }
 
-func (em *eventManager) FireRetrievalQueryProgress(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
+func (em *EventManager) FireRetrievalQueryProgress(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
 	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
 		listener.RetrievalQueryProgress(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, stage)
 	})
 }
 
-func (em *eventManager) FireRetrievalQueryFailure(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, errString string) {
+func (em *EventManager) FireRetrievalQueryFailure(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, errString string) {
 	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
 		listener.RetrievalQueryFailure(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, errString)
 	})
 }
 
-func (em *eventManager) FireRetrievalQuerySuccess(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse) {
+func (em *EventManager) FireRetrievalQuerySuccess(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse) {
 	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
 		listener.RetrievalQuerySuccess(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, queryResponse)
 	})
 }
 
-func (em *eventManager) FireRetrievalProgress(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
+func (em *EventManager) FireRetrievalProgress(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
 	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
 		listener.RetrievalProgress(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, stage)
 	})
 }
 
-func (em *eventManager) FireRetrievalSuccess(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, receivedSize uint64) {
+func (em *EventManager) FireRetrievalSuccess(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, receivedSize uint64) {
 	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
 		listener.RetrievalSuccess(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, receivedSize)
 	})
 }
 
-func (em *eventManager) FireRetrievalFailure(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, errString string) {
+func (em *EventManager) FireRetrievalFailure(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, errString string) {
 	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
 		listener.RetrievalFailure(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, errString)
 	})

--- a/filecoin/retrieverevents.go
+++ b/filecoin/retrieverevents.go
@@ -1,0 +1,147 @@
+package filecoin
+
+import (
+	"sync"
+	"time"
+
+	"github.com/application-research/filclient"
+	"github.com/application-research/filclient/rep"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/google/uuid"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+// RetrievalEventListener defines a type that receives events fired during a
+// retrieval process, including the process of querying available storage
+// providers to find compatible ones to attempt retrieval from.
+type RetrievalEventListener interface {
+	// RetrievalQueryStart defines the start of the process of querying all
+	// storage providers that are known to have this CID
+	RetrievalQueryStart(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, candidateCount int)
+
+	// RetrievalQueryProgress events occur during the query process, stages
+	// include: connect and query-ask
+	RetrievalQueryProgress(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode)
+
+	// RetrievalQueryFailure events occur on the failure of querying a storage
+	// provider. A query will result in either a RetrievalQueryFailure or
+	// a RetrievalQuerySuccess event.
+	RetrievalQueryFailure(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, err error)
+
+	// RetrievalQueryFailure events occur on successfully querying a storage
+	// provider. A query will result in either a RetrievalQueryFailure or
+	// a RetrievalQuerySuccess event.
+	RetrievalQuerySuccess(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse)
+
+	// RetrievalStart events are fired at the beginning of retrieval-proper, once
+	// a storage provider is selected for retrieval. Note that upon failure,
+	// another storage provider may be selected so multiple RetrievalStart events
+	// may occur for the same retrieval.
+	RetrievalStart(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, rootCid cid.Cid, storageProviderId peer.ID)
+
+	// RetrievalProgress events occur during the process of a retrieval. The
+	// Success and failure progress event types are not reported here, but are
+	// signalled via RetrievalSuccess or RetrievalFailure.
+	RetrievalProgress(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode)
+
+	// RetrievalSuccess events occur on the success of a retrieval. A retrieval
+	// will result in either a RetrievalQueryFailure or a RetrievalQuerySuccess
+	// event.
+	RetrievalSuccess(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, retrievalStats filclient.RetrievalStats)
+
+	// RetrievalFailure events occur on the failure of a retrieval. A retrieval
+	// will result in either a RetrievalQueryFailure or a RetrievalQuerySuccess
+	// event.
+	RetrievalFailure(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, err error)
+}
+
+type eventManager struct {
+	lk        sync.RWMutex
+	idx       int
+	listeners map[int]RetrievalEventListener
+}
+
+func newEventManager() *eventManager {
+	return &eventManager{listeners: make(map[int]RetrievalEventListener)}
+}
+
+func (em *eventManager) RegisterListener(listener RetrievalEventListener) func() {
+	em.lk.Lock()
+	defer em.lk.Unlock()
+
+	idx := em.idx
+	em.idx++
+	em.listeners[idx] = listener
+
+	// return unregister function
+	return func() {
+		em.lk.Lock()
+		defer em.lk.Unlock()
+		delete(em.listeners, idx)
+	}
+}
+
+func (em *eventManager) fireEvent(cb func(timestamp time.Time, listener RetrievalEventListener)) {
+	timestamp := time.Now()
+	go func() {
+		em.lk.RLock()
+		listeners := make([]RetrievalEventListener, 0)
+		for _, listener := range em.listeners {
+			listeners = append(listeners, listener)
+		}
+		em.lk.RUnlock()
+
+		for _, listener := range listeners {
+			cb(timestamp, listener)
+		}
+	}()
+}
+
+func (em *eventManager) FireRetrievalQueryStart(retrievalId uuid.UUID, requestedCid cid.Cid, candidateCount int) {
+	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
+		listener.RetrievalQueryStart(retrievalId, timestamp, requestedCid, candidateCount)
+	})
+}
+
+func (em *eventManager) FireRetrievalQueryProgress(retrievalId uuid.UUID, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
+	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
+		listener.RetrievalQueryProgress(retrievalId, timestamp, requestedCid, storageProviderId, stage)
+	})
+}
+
+func (em *eventManager) FireRetrievalQueryFailure(retrievalId uuid.UUID, requestedCid cid.Cid, storageProviderId peer.ID, err error) {
+	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
+		listener.RetrievalQueryFailure(retrievalId, timestamp, requestedCid, storageProviderId, err)
+	})
+}
+
+func (em *eventManager) FireRetrievalQuerySuccess(retrievalId uuid.UUID, requestedCid cid.Cid, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse) {
+	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
+		listener.RetrievalQuerySuccess(retrievalId, timestamp, requestedCid, storageProviderId, queryResponse)
+	})
+}
+
+func (em *eventManager) FireRetrievalStart(retrievalId uuid.UUID, requestedCid cid.Cid, rootCid cid.Cid, storageProviderId peer.ID) {
+	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
+		listener.RetrievalStart(retrievalId, timestamp, requestedCid, rootCid, storageProviderId)
+	})
+}
+
+func (em *eventManager) FireRetrievalProgress(retrievalId uuid.UUID, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
+	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
+		listener.RetrievalProgress(retrievalId, timestamp, requestedCid, storageProviderId, stage)
+	})
+}
+
+func (em *eventManager) FireRetrievalSuccess(retrievalId uuid.UUID, requestedCid cid.Cid, storageProviderId peer.ID, retrievalStats filclient.RetrievalStats) {
+	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
+		listener.RetrievalSuccess(retrievalId, timestamp, requestedCid, storageProviderId, retrievalStats)
+	})
+}
+
+func (em *eventManager) FireRetrievalFailure(retrievalId uuid.UUID, requestedCid cid.Cid, storageProviderId peer.ID, err error) {
+	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
+		listener.RetrievalFailure(retrievalId, timestamp, requestedCid, storageProviderId, err)
+	})
+}

--- a/filecoin/retrieverevents.go
+++ b/filecoin/retrieverevents.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/application-research/filclient"
 	"github.com/application-research/filclient/rep"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/google/uuid"
@@ -16,44 +15,34 @@ import (
 // retrieval process, including the process of querying available storage
 // providers to find compatible ones to attempt retrieval from.
 type RetrievalEventListener interface {
-	// RetrievalQueryStart defines the start of the process of querying all
-	// storage providers that are known to have this CID
-	RetrievalQueryStart(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, candidateCount int)
-
 	// RetrievalQueryProgress events occur during the query process, stages
 	// include: connect and query-ask
-	RetrievalQueryProgress(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode)
+	RetrievalQueryProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode)
 
 	// RetrievalQueryFailure events occur on the failure of querying a storage
 	// provider. A query will result in either a RetrievalQueryFailure or
 	// a RetrievalQuerySuccess event.
-	RetrievalQueryFailure(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, err error)
+	RetrievalQueryFailure(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, errString string)
 
 	// RetrievalQueryFailure events occur on successfully querying a storage
 	// provider. A query will result in either a RetrievalQueryFailure or
 	// a RetrievalQuerySuccess event.
-	RetrievalQuerySuccess(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse)
-
-	// RetrievalStart events are fired at the beginning of retrieval-proper, once
-	// a storage provider is selected for retrieval. Note that upon failure,
-	// another storage provider may be selected so multiple RetrievalStart events
-	// may occur for the same retrieval.
-	RetrievalStart(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, rootCid cid.Cid, storageProviderId peer.ID)
+	RetrievalQuerySuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse)
 
 	// RetrievalProgress events occur during the process of a retrieval. The
 	// Success and failure progress event types are not reported here, but are
 	// signalled via RetrievalSuccess or RetrievalFailure.
-	RetrievalProgress(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode)
+	RetrievalProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode)
 
 	// RetrievalSuccess events occur on the success of a retrieval. A retrieval
 	// will result in either a RetrievalQueryFailure or a RetrievalQuerySuccess
 	// event.
-	RetrievalSuccess(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, retrievalStats filclient.RetrievalStats)
+	RetrievalSuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, receivedSize uint64)
 
 	// RetrievalFailure events occur on the failure of a retrieval. A retrieval
 	// will result in either a RetrievalQueryFailure or a RetrievalQuerySuccess
 	// event.
-	RetrievalFailure(retrievalId uuid.UUID, timestamp time.Time, requestedCid cid.Cid, storageProviderId peer.ID, err error)
+	RetrievalFailure(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, errString string)
 }
 
 type eventManager struct {
@@ -98,50 +87,38 @@ func (em *eventManager) fireEvent(cb func(timestamp time.Time, listener Retrieva
 	}()
 }
 
-func (em *eventManager) FireRetrievalQueryStart(retrievalId uuid.UUID, requestedCid cid.Cid, candidateCount int) {
+func (em *eventManager) FireRetrievalQueryProgress(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
 	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
-		listener.RetrievalQueryStart(retrievalId, timestamp, requestedCid, candidateCount)
+		listener.RetrievalQueryProgress(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, stage)
 	})
 }
 
-func (em *eventManager) FireRetrievalQueryProgress(retrievalId uuid.UUID, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
+func (em *eventManager) FireRetrievalQueryFailure(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, errString string) {
 	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
-		listener.RetrievalQueryProgress(retrievalId, timestamp, requestedCid, storageProviderId, stage)
+		listener.RetrievalQueryFailure(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, errString)
 	})
 }
 
-func (em *eventManager) FireRetrievalQueryFailure(retrievalId uuid.UUID, requestedCid cid.Cid, storageProviderId peer.ID, err error) {
+func (em *eventManager) FireRetrievalQuerySuccess(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse) {
 	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
-		listener.RetrievalQueryFailure(retrievalId, timestamp, requestedCid, storageProviderId, err)
+		listener.RetrievalQuerySuccess(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, queryResponse)
 	})
 }
 
-func (em *eventManager) FireRetrievalQuerySuccess(retrievalId uuid.UUID, requestedCid cid.Cid, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse) {
+func (em *eventManager) FireRetrievalProgress(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
 	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
-		listener.RetrievalQuerySuccess(retrievalId, timestamp, requestedCid, storageProviderId, queryResponse)
+		listener.RetrievalProgress(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, stage)
 	})
 }
 
-func (em *eventManager) FireRetrievalStart(retrievalId uuid.UUID, requestedCid cid.Cid, rootCid cid.Cid, storageProviderId peer.ID) {
+func (em *eventManager) FireRetrievalSuccess(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, receivedSize uint64) {
 	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
-		listener.RetrievalStart(retrievalId, timestamp, requestedCid, rootCid, storageProviderId)
+		listener.RetrievalSuccess(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, receivedSize)
 	})
 }
 
-func (em *eventManager) FireRetrievalProgress(retrievalId uuid.UUID, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
+func (em *eventManager) FireRetrievalFailure(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, errString string) {
 	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
-		listener.RetrievalProgress(retrievalId, timestamp, requestedCid, storageProviderId, stage)
-	})
-}
-
-func (em *eventManager) FireRetrievalSuccess(retrievalId uuid.UUID, requestedCid cid.Cid, storageProviderId peer.ID, retrievalStats filclient.RetrievalStats) {
-	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
-		listener.RetrievalSuccess(retrievalId, timestamp, requestedCid, storageProviderId, retrievalStats)
-	})
-}
-
-func (em *eventManager) FireRetrievalFailure(retrievalId uuid.UUID, requestedCid cid.Cid, storageProviderId peer.ID, err error) {
-	em.fireEvent(func(timestamp time.Time, listener RetrievalEventListener) {
-		listener.RetrievalFailure(retrievalId, timestamp, requestedCid, storageProviderId, err)
+		listener.RetrievalFailure(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, errString)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,8 @@ require (
 	github.com/filecoin-project/index-provider v0.6.1
 	github.com/filecoin-project/lotus v1.15.1-rc5
 	github.com/filecoin-project/storetheindex v0.4.0
+	github.com/frankban/quicktest v1.14.3
+	github.com/google/uuid v1.3.0
 	github.com/ipfs/go-bitswap v0.5.2-0.20211214021705-dbfc6a1d986e
 	github.com/ipfs/go-block-format v0.0.3
 	github.com/ipfs/go-blockservice v0.2.1
@@ -27,6 +29,7 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ipfs/go-merkledag v0.5.1
 	github.com/ipfs/go-peertaskqueue v0.7.1
+	github.com/ipld/go-ipld-prime v0.16.0
 	github.com/libp2p/go-libp2p v0.18.0
 	github.com/libp2p/go-libp2p-core v0.14.0
 	github.com/libp2p/go-libp2p-kad-dht v0.15.0
@@ -127,8 +130,8 @@ require (
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.3 // indirect
+	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/graph-gophers/graphql-go v1.2.0 // indirect
@@ -168,7 +171,6 @@ require (
 	github.com/ipld/go-car v0.3.4-0.20220124154420-9c7956a6eb9d // indirect
 	github.com/ipld/go-car/v2 v2.1.2-0.20220124154420-9c7956a6eb9d // indirect
 	github.com/ipld/go-codec-dagpb v1.4.0 // indirect
-	github.com/ipld/go-ipld-prime v0.16.0 // indirect
 	github.com/ipld/go-ipld-selector-text-lite v0.0.1 // indirect
 	github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
@@ -182,6 +184,8 @@ require (
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/koron/go-ssdp v0.0.2 // indirect
+	github.com/kr/pretty v0.3.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/libp2p/go-buffer-pool v0.0.2 // indirect
 	github.com/libp2p/go-cidranger v1.1.0 // indirect
 	github.com/libp2p/go-conn-security-multistream v0.3.0 // indirect
@@ -264,6 +268,7 @@ require (
 	github.com/raulk/go-watchdog v1.2.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/rogpeppe/go-internal v1.6.1 // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shirou/gopsutil v2.18.12+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
-	github.com/application-research/filclient v0.0.0-20220622165741-3ca6a3f3bc7a
+	github.com/application-research/filclient v0.0.0-20220721124343-16158510201c
 	github.com/dustin/go-humanize v1.0.0
 	github.com/filecoin-project/go-address v0.0.6
 	github.com/filecoin-project/go-data-transfer v1.15.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
-	github.com/application-research/filclient v0.0.0-20220721124343-16158510201c
+	github.com/application-research/filclient v0.0.0-20220721211630-f4aef771d13e
 	github.com/dustin/go-humanize v1.0.0
 	github.com/filecoin-project/go-address v0.0.6
 	github.com/filecoin-project/go-data-transfer v1.15.1

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/application-research/filclient v0.0.0-20220622165741-3ca6a3f3bc7a h1:Xw4boQwfwLqBV9dx69j43XOdokgFVjfZ+Dnd6l+KJw8=
-github.com/application-research/filclient v0.0.0-20220622165741-3ca6a3f3bc7a/go.mod h1:QSOQ2dcnSvucj23jOg535mvTMezoNV0bdJbIySoDaOg=
+github.com/application-research/filclient v0.0.0-20220721124343-16158510201c h1:e5y8fTQn9Cdup1hNk/i9IZFVNQeRYWor9McNCNjTtuM=
+github.com/application-research/filclient v0.0.0-20220721124343-16158510201c/go.mod h1:QSOQ2dcnSvucj23jOg535mvTMezoNV0bdJbIySoDaOg=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,9 @@ github.com/franela/goblin v0.0.0-20210519012713-85d372ac71e2/go.mod h1:VzmDKDJVZ
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
-github.com/frankban/quicktest v1.14.2 h1:SPb1KFFmM+ybpEjPUhCCkZOM5xlovT5UbrMvWnXyBns=
 github.com/frankban/quicktest v1.14.2/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
+github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
+github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/application-research/filclient v0.0.0-20220721124343-16158510201c h1:e5y8fTQn9Cdup1hNk/i9IZFVNQeRYWor9McNCNjTtuM=
-github.com/application-research/filclient v0.0.0-20220721124343-16158510201c/go.mod h1:QSOQ2dcnSvucj23jOg535mvTMezoNV0bdJbIySoDaOg=
+github.com/application-research/filclient v0.0.0-20220721211630-f4aef771d13e h1:7RV/dTY1NsF28VNMtQwMgvYWnJE1SmktFJelZX54Mo4=
+github.com/application-research/filclient v0.0.0-20220721211630-f4aef771d13e/go.mod h1:QSOQ2dcnSvucj23jOg535mvTMezoNV0bdJbIySoDaOg=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
Closes: https://github.com/application-research/autoretrieve/issues/96

I thought I'd have a go at this, I think we discussed dividing it up this way since @kylehuntsman is so keen to do https://github.com/filecoin-project/autoretrieve-deploy/issues/2 (and I'm not). This adds an HTTP PUT to `https://foo.bar/retrieval-event/~uuid~/providers/~minerid` for both successful and unsuccessful retrievals, using data I could collect at that point and seems reasonable to want. We discussed, (and I think agreed on?) flattening it to just the one endpoint and letting the server handle aggregation of uuids. The URL string before `/retrieval-event...` comes from the config, a new, optional field: `event-recorder-endpoint-url`—if not set, it's all a noop.

See the `event` struct for what's included in the message. One thing I couldn't add in is "stage" because I couldn't figure out what that might refer to!