### PR TITLE
fix: return errors from WriteConfig in gen-config cli

### DIFF
--- a/main.go
+++ b/main.go
@@ -248,9 +248,7 @@ func cmdGenConfig(ctx *cli.Context) error {
 
 	cfgPath := fullConfigPath(ctx)
 	fmt.Printf("Writing config to '%s'\n", cfgPath)
-	WriteConfig(cfg, cfgPath)
-
-	return nil
+	return WriteConfig(cfg, cfgPath)
 }
 
 func cmdPrintConfig(ctx *cli.Context) error {


### PR DESCRIPTION
Discovered after trying to run `gen-config` post Docker usage which had my ~/.autoretrieve owned by root so unwritable but silently failing.

With this change I get:

```
2022-07-14T11:40:45.299+1000    FATAL   autoretrieve    autoretrieve/main.go:105        open /home/rvagg/.autoretrieve/config.yaml: permission denied
```