### PR TITLE
feat: add timeout using deadline for RetrievalQueryToPeer calls

### DIFF
--- a/filecoin/retriever.go
+++ b/filecoin/retriever.go
@@ -412,6 +412,13 @@ func (retriever *Retriever) queryCandidates(ctx context.Context, cid cid.Cid, ca
 		go func(i int, candidate RetrievalCandidate) {
 			defer wg.Done()
 
+			minerCfgs := retriever.config.MinerConfigs[candidate.MinerPeer.ID]
+			if minerCfgs.RetrievalTimeout != 0 {
+				var cancelFunc func()
+				ctx, cancelFunc = context.WithDeadline(ctx, time.Now().Add(minerCfgs.RetrievalTimeout))
+				defer cancelFunc()
+			}
+
 			query, err := retriever.filClient.RetrievalQueryToPeer(ctx, candidate.MinerPeer, candidate.RootCid)
 			if err != nil {
 				log.Errorf(


### PR DESCRIPTION
The lack of explicit timeout on query calls seems like an oversight to me. I'm not currently seeing endless connection attempts leaking in my local experiments but I imagine there's some kind of implicit timeout that's coming in to play in libp2p or some other network layer so it's probably cleaning up _eventually_. But _eventually_ is not really what we want - queries should be quick, and we should be able to drop those that don't respond quickly. This PR reuses the per-miner timeout which defaults to 1m, but we could introduce a new one just for query phase and set it even shorter. The per-miner timeout timer is reset on bytes-received so it's probably reasonable that it's reused in this way I reckon.

The deadline should get reused as a libp2p socket deadline @ https://github.com/application-research/filclient/blob/cb126018ee48269269ceef8c5d39d3bf0806f5b3/filclient.go#L466-L470