### PR TITLE
ci: use GITHUB_TOKEN when preparing FFI

### DIFF
--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -3,7 +3,11 @@ runs:
   steps:
     - name: Prepare for FFI build
       shell: bash
-      run: make ffi_install_dependencies
+      run: make ffi_install_dependencies  
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
     - name: Install & Build FFI
       shell: bash
       run: make all
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -3,7 +3,7 @@ runs:
   steps:
     - name: Prepare for FFI build
       shell: bash
-      run: make ffi_install_dependencies  
+      run: make ffi_install_dependencies
       env:
         GITHUB_TOKEN: ${{ github.token }}
     - name: Install & Build FFI


### PR DESCRIPTION
Requires https://github.com/filecoin-project/filecoin-ffi/pull/310

This should help not getting rate limited when getting FFI.

The error that we encountered during the tests suggests that making authenticated calls is the way to go:
```
++ curl --retry 3 --location https://api.github.com/repos/filecoin-project/filecoin-ffi/releases/tags/5d00bb4365a97890
++ echo '{"message":"API rate limit exceeded for 208.83.5.75. (But here'\''s the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}'
```
