### PR TITLE
Update to use new filclient event reporter

### DIFF
--- a/filecoin/eventrecorder/eventrecorder.go
+++ b/filecoin/eventrecorder/eventrecorder.go
@@ -33,21 +33,22 @@ type EventRecorder struct {
 }
 
 type eventReport struct {
-	RetrievalId       uuid.UUID              `json:"retrievalId"`
-	InstanceId        string                 `json:"instanceId"`
-	Cid               string                 `json:"cid"`
-	StorageProviderId peer.ID                `json:"storageProviderId"`
-	Phase             rep.Phase              `json:"phase"`
-	PhaseStartTime    time.Time              `json:"phaseStartTime"`
-	Event             rep.RetrievalEventCode `json:"event"`
-	EventTime         time.Time              `json:"eventTime"`
-	EventDetails      interface{}            `json:"eventDetails,omitempty"`
+	RetrievalId       uuid.UUID   `json:"retrievalId"`
+	InstanceId        string      `json:"instanceId"`
+	Cid               string      `json:"cid"`
+	StorageProviderId peer.ID     `json:"storageProviderId"`
+	Phase             rep.Phase   `json:"phase"`
+	PhaseStartTime    time.Time   `json:"phaseStartTime"`
+	Event             rep.Code    `json:"event"`
+	EventTime         time.Time   `json:"eventTime"`
+	EventDetails      interface{} `json:"eventDetails,omitempty"`
 }
 
 // eventDetailsSuccess is for the EventDetails in the case of a retrieval
 // success
 type eventDetailsSuccess struct {
 	ReceivedSize uint64 `json:"receivedSize"`
+	ReceivedCids int64  `json:"receivedCids"`
 }
 
 // eventDetailsError is for the EventDetails in the case of a query or retrieval
@@ -57,7 +58,7 @@ type eventDetailsError struct {
 }
 
 // QueryProgress events occur during the query process
-func (er *EventRecorder) QueryProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, event rep.RetrievalEventCode) {
+func (er *EventRecorder) QueryProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, event rep.Code) {
 	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.QueryPhase, phaseStartTime, event, eventTime, nil}
 	er.recordEvent("QueryProgress", evt)
 }
@@ -66,7 +67,7 @@ func (er *EventRecorder) QueryProgress(retrievalId uuid.UUID, phaseStartTime, ev
 // provider. A query will result in either a QueryFailure or
 // a QuerySuccess event.
 func (er *EventRecorder) QueryFailure(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, errorString string) {
-	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.QueryPhase, phaseStartTime, rep.RetrievalEventFailure, eventTime, nil}
+	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.QueryPhase, phaseStartTime, rep.FailureCode, eventTime, nil}
 	evt.EventDetails = &eventDetailsError{errorString}
 	er.recordEvent("QueryFailure", evt)
 }
@@ -75,7 +76,7 @@ func (er *EventRecorder) QueryFailure(retrievalId uuid.UUID, phaseStartTime, eve
 // provider. A query will result in either a QueryFailure or
 // a QuerySuccess event.
 func (er *EventRecorder) QuerySuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, queryResponse retrievalmarket.QueryResponse) {
-	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.QueryPhase, phaseStartTime, rep.RetrievalEventQueryAsk, eventTime, nil}
+	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.QueryPhase, phaseStartTime, rep.QueryAskedCode, eventTime, nil}
 	evt.EventDetails = &queryResponse
 	er.recordEvent("QuerySuccess", evt)
 }
@@ -83,7 +84,7 @@ func (er *EventRecorder) QuerySuccess(retrievalId uuid.UUID, phaseStartTime, eve
 // RetrievalProgress events occur during the process of a retrieval. The
 // Success and failure progress event types are not reported here, but are
 // signalled via RetrievalSuccess or RetrievalFailure.
-func (er *EventRecorder) RetrievalProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, event rep.RetrievalEventCode) {
+func (er *EventRecorder) RetrievalProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, event rep.Code) {
 	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.RetrievalPhase, phaseStartTime, event, eventTime, nil}
 	er.recordEvent("RetrievalProgress", evt)
 }
@@ -91,17 +92,16 @@ func (er *EventRecorder) RetrievalProgress(retrievalId uuid.UUID, phaseStartTime
 // RetrievalSuccess events occur on the success of a retrieval. A retrieval
 // will result in either a QueryFailure or a QuerySuccess
 // event.
-func (er *EventRecorder) RetrievalSuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, retrievedSize uint64) {
-	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.RetrievalPhase, phaseStartTime, rep.RetrievalEventSuccess, eventTime, nil}
-	evt.EventDetails = &eventDetailsSuccess{retrievedSize}
+func (er *EventRecorder) RetrievalSuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, retrievedSize uint64, receivedCids int64) {
+	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.RetrievalPhase, phaseStartTime, rep.SuccessCode, eventTime, nil}
+	evt.EventDetails = &eventDetailsSuccess{retrievedSize, receivedCids}
 	er.recordEvent("RetrievalSuccess", evt)
 }
 
 // RetrievalFailure events occur on the failure of a retrieval. A retrieval
-// will result in either a QueryFailure or a QuerySuccess
-// event.
+// will result in either a QueryFailure or a QuerySuccess event.
 func (er *EventRecorder) RetrievalFailure(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, errorString string) {
-	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.RetrievalPhase, phaseStartTime, rep.RetrievalEventFailure, eventTime, nil}
+	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.RetrievalPhase, phaseStartTime, rep.FailureCode, eventTime, nil}
 	evt.EventDetails = &eventDetailsError{errorString}
 	er.recordEvent("RetrievalFailure", evt)
 }

--- a/filecoin/eventrecorder/eventrecorder_test.go
+++ b/filecoin/eventrecorder/eventrecorder_test.go
@@ -81,7 +81,7 @@ func TestEventRecorder(t *testing.T) {
 		{
 			name: "RetrievalSuccess",
 			exec: func(t *testing.T, er *eventrecorder.EventRecorder, id uuid.UUID, etime, ptime time.Time, spid peer.ID) {
-				er.RetrievalSuccess(id, ptime, etime, testCid1, spid, uint64(2020))
+				er.RetrievalSuccess(id, ptime, etime, testCid1, spid, uint64(2020), 3030)
 
 				qt.Assert(t, req.Length(), qt.Equals, int64(9))
 				verifyStringNode(t, req, "retrievalId", id.String())
@@ -95,8 +95,9 @@ func TestEventRecorder(t *testing.T) {
 
 				detailsNode, err := req.LookupByString("eventDetails")
 				qt.Assert(t, err, qt.IsNil)
-				qt.Assert(t, detailsNode.Length(), qt.Equals, int64(1))
+				qt.Assert(t, detailsNode.Length(), qt.Equals, int64(2))
 				verifyIntNode(t, detailsNode, "receivedSize", 2020)
+				verifyIntNode(t, detailsNode, "receivedCids", 3030)
 			},
 		},
 		{
@@ -144,7 +145,7 @@ func TestEventRecorder(t *testing.T) {
 		{
 			name: "QueryProgress",
 			exec: func(t *testing.T, er *eventrecorder.EventRecorder, id uuid.UUID, etime, ptime time.Time, spid peer.ID) {
-				er.QueryProgress(id, ptime, etime, testCid1, spid, rep.RetrievalEventConnect)
+				er.QueryProgress(id, ptime, etime, testCid1, spid, rep.ConnectedCode)
 
 				qt.Assert(t, req.Length(), qt.Equals, int64(8))
 				verifyStringNode(t, req, "retrievalId", id.String())
@@ -160,7 +161,7 @@ func TestEventRecorder(t *testing.T) {
 		{
 			name: "RetrievalProgress",
 			exec: func(t *testing.T, er *eventrecorder.EventRecorder, id uuid.UUID, etime, ptime time.Time, spid peer.ID) {
-				er.RetrievalProgress(id, ptime, etime, testCid1, spid, rep.RetrievalEventFirstByte)
+				er.RetrievalProgress(id, ptime, etime, testCid1, spid, rep.FirstByteCode)
 
 				qt.Assert(t, req.Length(), qt.Equals, int64(8))
 				verifyStringNode(t, req, "retrievalId", id.String())

--- a/filecoin/retrieverevents.go
+++ b/filecoin/retrieverevents.go
@@ -18,7 +18,7 @@ import (
 type RetrievalEventListener interface {
 	// QueryProgress events occur during the query process, stages.
 	// Currently this should just include a "connected" event.
-	QueryProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode)
+	QueryProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.Code)
 
 	// QueryFailure events occur on the failure of querying a storage
 	// provider. A query will result in either a QueryFailure or
@@ -33,12 +33,12 @@ type RetrievalEventListener interface {
 	// RetrievalProgress events occur during the process of a retrieval. The
 	// Success and failure progress event types are not reported here, but are
 	// signalled via RetrievalSuccess or RetrievalFailure.
-	RetrievalProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.RetrievalEventCode)
+	RetrievalProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, stage rep.Code)
 
 	// RetrievalSuccess events occur on the success of a retrieval. A retrieval
 	// will result in either a QueryFailure or a QuerySuccess
 	// event.
-	RetrievalSuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, receivedSize uint64)
+	RetrievalSuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, receivedSize uint64, receivedCids int64)
 
 	// RetrievalFailure events occur on the failure of a retrieval. A retrieval
 	// will result in either a QueryFailure or a QuerySuccess
@@ -114,7 +114,7 @@ func (em *EventManager) queueEvent(cb func(timestamp time.Time, listener Retriev
 }
 
 // FireQueryProgress calls QueryProgress for all listeners
-func (em *EventManager) FireQueryProgress(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
+func (em *EventManager) FireQueryProgress(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, stage rep.Code) {
 	em.queueEvent(func(timestamp time.Time, listener RetrievalEventListener) {
 		listener.QueryProgress(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, stage)
 	})
@@ -135,16 +135,16 @@ func (em *EventManager) FireQuerySuccess(retrievalId uuid.UUID, requestedCid cid
 }
 
 // FireRetrievalProgress calls RetrievalProgress for all listeners
-func (em *EventManager) FireRetrievalProgress(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, stage rep.RetrievalEventCode) {
+func (em *EventManager) FireRetrievalProgress(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, stage rep.Code) {
 	em.queueEvent(func(timestamp time.Time, listener RetrievalEventListener) {
 		listener.RetrievalProgress(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, stage)
 	})
 }
 
 // FireRetrievalSuccess calls RetrievalSuccess for all listeners
-func (em *EventManager) FireRetrievalSuccess(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, receivedSize uint64) {
+func (em *EventManager) FireRetrievalSuccess(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, receivedSize uint64, receivedCids int64) {
 	em.queueEvent(func(timestamp time.Time, listener RetrievalEventListener) {
-		listener.RetrievalSuccess(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, receivedSize)
+		listener.RetrievalSuccess(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, receivedSize, receivedCids)
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
-	github.com/application-research/filclient v0.0.0-20220721211630-f4aef771d13e
+	github.com/application-research/filclient v0.0.0-20220801053338-7de328613bf9
 	github.com/dustin/go-humanize v1.0.0
 	github.com/filecoin-project/go-address v0.0.6
 	github.com/filecoin-project/go-data-transfer v1.15.1

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/application-research/filclient v0.0.0-20220721211630-f4aef771d13e h1:7RV/dTY1NsF28VNMtQwMgvYWnJE1SmktFJelZX54Mo4=
-github.com/application-research/filclient v0.0.0-20220721211630-f4aef771d13e/go.mod h1:QSOQ2dcnSvucj23jOg535mvTMezoNV0bdJbIySoDaOg=
+github.com/application-research/filclient v0.0.0-20220801053338-7de328613bf9 h1:5X14c8WlfA4+VReNHGpUKqmSNkumqT/YMqMHYUw0hQM=
+github.com/application-research/filclient v0.0.0-20220801053338-7de328613bf9/go.mod h1:QSOQ2dcnSvucj23jOg535mvTMezoNV0bdJbIySoDaOg=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
Ref: https://github.com/application-research/filclient/pull/89 - depends on that branch's commit for filclient

This is really about cleaning up the "event" vs "state" thing now we've moved to a pure event model and not tracking state in our reporting, but it also adds `"receivedCids"` to the success case for reporting.