### PR TITLE
fix: update `eventReport.event` property to `eventName`

### DIFF
--- a/filecoin/eventrecorder/eventrecorder.go
+++ b/filecoin/eventrecorder/eventrecorder.go
@@ -40,7 +40,7 @@ type eventReport struct {
 	StorageProviderId peer.ID     `json:"storageProviderId"`
 	Phase             rep.Phase   `json:"phase"`
 	PhaseStartTime    time.Time   `json:"phaseStartTime"`
-	Event             rep.Code    `json:"event"`
+	EventName         rep.Code    `json:"eventName"`
 	EventTime         time.Time   `json:"eventTime"`
 	EventDetails      interface{} `json:"eventDetails,omitempty"`
 }
@@ -59,8 +59,8 @@ type eventDetailsError struct {
 }
 
 // QueryProgress events occur during the query process
-func (er *EventRecorder) QueryProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, event rep.Code) {
-	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.QueryPhase, phaseStartTime, event, eventTime, nil}
+func (er *EventRecorder) QueryProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, eventName rep.Code) {
+	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.QueryPhase, phaseStartTime, eventName, eventTime, nil}
 	er.recordEvent("QueryProgress", evt)
 }
 
@@ -85,8 +85,8 @@ func (er *EventRecorder) QuerySuccess(retrievalId uuid.UUID, phaseStartTime, eve
 // RetrievalProgress events occur during the process of a retrieval. The
 // Success and failure progress event types are not reported here, but are
 // signalled via RetrievalSuccess or RetrievalFailure.
-func (er *EventRecorder) RetrievalProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, event rep.Code) {
-	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.RetrievalPhase, phaseStartTime, event, eventTime, nil}
+func (er *EventRecorder) RetrievalProgress(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, eventName rep.Code) {
+	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.RetrievalPhase, phaseStartTime, eventName, eventTime, nil}
 	er.recordEvent("RetrievalProgress", evt)
 }
 

--- a/filecoin/eventrecorder/eventrecorder_test.go
+++ b/filecoin/eventrecorder/eventrecorder_test.go
@@ -63,7 +63,7 @@ func TestEventRecorder(t *testing.T) {
 				verifyStringNode(t, req, "storageProviderId", spid.String())
 				verifyStringNode(t, req, "phase", "query")
 				verifyStringNode(t, req, "phaseStartTime", ptime.Format(time.RFC3339Nano))
-				verifyStringNode(t, req, "event", "query-asked")
+				verifyStringNode(t, req, "eventName", "query-asked")
 				verifyStringNode(t, req, "eventTime", etime.Format(time.RFC3339Nano))
 
 				detailsNode, err := req.LookupByString("eventDetails")
@@ -92,7 +92,7 @@ func TestEventRecorder(t *testing.T) {
 				verifyStringNode(t, req, "storageProviderId", spid.String())
 				verifyStringNode(t, req, "phase", "retrieval")
 				verifyStringNode(t, req, "phaseStartTime", ptime.Format(time.RFC3339Nano))
-				verifyStringNode(t, req, "event", "success")
+				verifyStringNode(t, req, "eventName", "success")
 				verifyStringNode(t, req, "eventTime", etime.Format(time.RFC3339Nano))
 
 				detailsNode, err := req.LookupByString("eventDetails")
@@ -114,7 +114,7 @@ func TestEventRecorder(t *testing.T) {
 				verifyStringNode(t, req, "storageProviderId", spid.String())
 				verifyStringNode(t, req, "phase", "query")
 				verifyStringNode(t, req, "phaseStartTime", ptime.Format(time.RFC3339Nano))
-				verifyStringNode(t, req, "event", "failure")
+				verifyStringNode(t, req, "eventName", "failure")
 				verifyStringNode(t, req, "eventTime", etime.Format(time.RFC3339Nano))
 
 				detailsNode, err := req.LookupByString("eventDetails")
@@ -135,7 +135,7 @@ func TestEventRecorder(t *testing.T) {
 				verifyStringNode(t, req, "storageProviderId", spid.String())
 				verifyStringNode(t, req, "phase", "retrieval")
 				verifyStringNode(t, req, "phaseStartTime", ptime.Format(time.RFC3339Nano))
-				verifyStringNode(t, req, "event", "failure")
+				verifyStringNode(t, req, "eventName", "failure")
 				verifyStringNode(t, req, "eventTime", etime.Format(time.RFC3339Nano))
 
 				detailsNode, err := req.LookupByString("eventDetails")
@@ -156,7 +156,7 @@ func TestEventRecorder(t *testing.T) {
 				verifyStringNode(t, req, "storageProviderId", spid.String())
 				verifyStringNode(t, req, "phase", "query")
 				verifyStringNode(t, req, "phaseStartTime", ptime.Format(time.RFC3339Nano))
-				verifyStringNode(t, req, "event", "connected")
+				verifyStringNode(t, req, "eventName", "connected")
 				verifyStringNode(t, req, "eventTime", etime.Format(time.RFC3339Nano))
 			},
 		},
@@ -172,7 +172,7 @@ func TestEventRecorder(t *testing.T) {
 				verifyStringNode(t, req, "storageProviderId", spid.String())
 				verifyStringNode(t, req, "phase", "retrieval")
 				verifyStringNode(t, req, "phaseStartTime", ptime.Format(time.RFC3339Nano))
-				verifyStringNode(t, req, "event", "first-byte-received")
+				verifyStringNode(t, req, "eventName", "first-byte-received")
 				verifyStringNode(t, req, "eventTime", etime.Format(time.RFC3339Nano))
 			},
 		},


### PR DESCRIPTION
Update the `eventReport.event` property to be `eventName`. The API is expecting `eventName`.