### PR TITLE
feat: strip newline from eventrecorder auth file, prepend "Basic "

### DIFF
--- a/autoretrieve.go
+++ b/autoretrieve.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -335,7 +336,7 @@ func loadEventRecorderAuth(dataDir string) (string, error) {
 		}
 		return "", nil
 	}
-	return string(eventRecorderAuth), nil
+	return strings.TrimSuffix(string(eventRecorderAuth), "\n"), nil
 }
 
 func loadPeerKey(dataDir string) (crypto.PrivKey, error) {

--- a/filecoin/eventrecorder/eventrecorder.go
+++ b/filecoin/eventrecorder/eventrecorder.go
@@ -3,6 +3,7 @@ package eventrecorder
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -124,7 +125,7 @@ func (er *EventRecorder) recordEvent(eventSource string, evt eventReport) {
 
 	// set authorization header if configured
 	if er.endpointAuthorization != "" {
-		req.Header.Set("Authorization", er.endpointAuthorization)
+		req.Header.Set("Authorization", fmt.Sprintf("Basic %s", er.endpointAuthorization))
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/filecoin/eventrecorder/eventrecorder_test.go
+++ b/filecoin/eventrecorder/eventrecorder_test.go
@@ -26,13 +26,13 @@ var testCid1 cid.Cid = mustCid("bafybeihrqe2hmfauph5yfbd6ucv7njqpiy4tvbewlvhzjl4
 func TestEventRecorder(t *testing.T) {
 	var req datamodel.Node
 	var path string
-	authHeaderValue := "Basic applesauce"
+	authHeaderValue := "applesauce"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var err error
 		req, err = ipld.DecodeStreaming(r.Body, dagjson.Decode)
 		qt.Assert(t, err, qt.IsNil)
 		path = r.URL.Path
-		qt.Assert(t, r.Header.Get("Authorization"), qt.Equals, authHeaderValue)
+		qt.Assert(t, r.Header.Get("Authorization"), qt.Equals, "Basic applesauce")
 	}))
 	defer ts.Close()
 


### PR DESCRIPTION
1. Quality of life improvement by stripping off a newline from the auth token file (so you can edit it with vim and not have to care)
2. Prepend `Basic ` to the string when sending it to the server so you don't need to add that into the file, it's just the key. I don't think we want to pretend there's any other fancy scheme going on so it should be OK hardwiring this. So now the kubernetes config thing just needs to spit that secret directly into that file and it should be fine.