### PR TITLE
Log http response code failures for event recorder

### DIFF
--- a/filecoin/eventrecorder/eventrecorder.go
+++ b/filecoin/eventrecorder/eventrecorder.go
@@ -135,4 +135,8 @@ func (er *EventRecorder) recordEvent(eventSource string, evt eventReport) {
 	}
 
 	defer resp.Body.Close() // error not so important at this point
+
+	if resp.StatusCode <= 200 || resp.StatusCode >= 299 {
+		log.Errorf("Expected success response code from event recorder server, got: %s", http.StatusText(resp.StatusCode))
+	}
 }


### PR DESCRIPTION
# Goals

Per golang docs, http.DefaultClient.Do does not return an error for non-200 level response codes, so log it manually.