### PR TITLE
feat: increase http reporting throughput, add timeout

### DIFF
--- a/autoretrieve.go
+++ b/autoretrieve.go
@@ -184,7 +184,7 @@ func New(cctx *cli.Context, dataDir string, cfg Config) (*Autoretrieve, error) {
 			if err != nil {
 				return nil, err
 			}
-			retriever.RegisterListener(eventrecorder.NewEventRecorder(cfg.InstanceId, cfg.EventRecorderEndpointURL, eventRecorderEndpointAuthorization))
+			retriever.RegisterListener(eventrecorder.NewEventRecorder(cctx.Context, cfg.InstanceId, cfg.EventRecorderEndpointURL, eventRecorderEndpointAuthorization))
 		}
 		if cfg.LogRetrievals {
 			w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)

--- a/filecoin/eventrecorder/eventrecorder.go
+++ b/filecoin/eventrecorder/eventrecorder.go
@@ -2,6 +2,7 @@ package eventrecorder
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -16,22 +17,44 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
+var HttpTimeout = 5 * time.Second
+var ParallelPosters = 5
+
 var _ filecoin.RetrievalEventListener = (*EventRecorder)(nil)
 
 var log = logging.Logger("eventrecorder")
 
 // NewEventRecorder creates a new event recorder with the ID of this instance
 // and the URL to POST to
-func NewEventRecorder(instanceId string, endpointURL string, endpointAuthorization string) *EventRecorder {
-	return &EventRecorder{instanceId, endpointURL, endpointAuthorization}
+func NewEventRecorder(ctx context.Context, instanceId string, endpointURL string, endpointAuthorization string) *EventRecorder {
+	er := &EventRecorder{
+		ctx,
+		instanceId,
+		endpointURL,
+		endpointAuthorization,
+		make(chan report, ParallelPosters*10),
+	}
+
+	for i := 0; i < ParallelPosters; i++ {
+		go er.postReports()
+	}
+
+	return er
+}
+
+type report struct {
+	src string
+	evt eventReport
 }
 
 // EventRecorder receives events from the retrieval manager and posts event data
 // to a given endpoint as POSTs with JSON bodies
 type EventRecorder struct {
+	ctx                   context.Context
 	instanceId            string
 	endpointURL           string
 	endpointAuthorization string
+	reportChan            chan report
 }
 
 type eventReport struct {
@@ -109,34 +132,49 @@ func (er *EventRecorder) RetrievalFailure(retrievalId uuid.UUID, phaseStartTime,
 }
 
 func (er *EventRecorder) recordEvent(eventSource string, evt eventReport) {
-	byts, err := json.Marshal(evt)
-	if err != nil {
-		log.Errorf("Failed to JSONify and encode event [%s]: %w", eventSource, err.Error())
-		return
+	select {
+	case <-er.ctx.Done():
+	case er.reportChan <- report{eventSource, evt}:
 	}
+}
 
-	req, err := http.NewRequest("POST", er.endpointURL, bytes.NewBufferString(string(byts)))
-	if err != nil {
-		log.Errorf("Failed to create POST request [%s] for recorder [%s]: %w", eventSource, er.endpointURL, err.Error())
-		return
-	}
+func (er *EventRecorder) postReports() {
+	client := http.Client{Timeout: HttpTimeout}
 
-	req.Header.Set("Content-Type", "application/json")
+	for {
+		select {
+		case <-er.ctx.Done():
+			return
+		case report := <-er.reportChan:
+			byts, err := json.Marshal(report.evt)
+			if err != nil {
+				log.Errorf("Failed to JSONify and encode event [%s]: %w", report.src, err.Error())
+				return
+			}
 
-	// set authorization header if configured
-	if er.endpointAuthorization != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Basic %s", er.endpointAuthorization))
-	}
+			req, err := http.NewRequest("POST", er.endpointURL, bytes.NewBufferString(string(byts)))
+			if err != nil {
+				log.Errorf("Failed to create POST request [%s] for recorder [%s]: %w", report.src, er.endpointURL, err.Error())
+				return
+			}
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		log.Errorf("Failed to POST event [%s] to recorder [%s]: %w", eventSource, er.endpointURL, err.Error())
-		return
-	}
+			req.Header.Set("Content-Type", "application/json")
 
-	defer resp.Body.Close() // error not so important at this point
+			// set authorization header if configured
+			if er.endpointAuthorization != "" {
+				req.Header.Set("Authorization", fmt.Sprintf("Basic %s", er.endpointAuthorization))
+			}
 
-	if resp.StatusCode <= 200 || resp.StatusCode >= 299 {
-		log.Errorf("Expected success response code from event recorder server, got: %s", http.StatusText(resp.StatusCode))
+			resp, err := client.Do(req)
+			if err != nil {
+				log.Errorf("Failed to POST event [%s] to recorder [%s]: %w", report.src, er.endpointURL, err.Error())
+				return
+			}
+
+			defer resp.Body.Close() // error not so important at this point
+			if resp.StatusCode <= 200 || resp.StatusCode >= 299 {
+				log.Errorf("Expected success response code from event recorder server, got: %s", http.StatusText(resp.StatusCode))
+			}
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/urfave/cli/v2 v2.3.0
 	go.opencensus.io v0.23.0
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
@@ -305,7 +306,6 @@ require (
 	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b // indirect
 	golang.org/x/exp v0.0.0-20210715201039-d37aa40e8013 // indirect
 	golang.org/x/mod v0.4.2 // indirect
-	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect


### PR DESCRIPTION
**Problem outline:** My local instance was starting to show a _lot_ of `ErrRetrievalAlreadyRunning` errors for given CIDs that were coming in over bitswap, which is a bit weird. The log output I'm getting to my terminal is showing many thousands of "active retrievals", and querying the event log database we're now collecting was showing high numbers as well. Taking a `goroutine` pprof was showing most of the goroutines stuck in filclient's event reporter, waiting for a listener to return.

This suggests (pretty strongly), that the `EventReporter` is not freeing up the channel it maintains for events to push through to the HTTP endpoint, and they're backing up rapidly.

My local connection is not great, and I'm ~250ms round-trip delayed from us-west (and I think we're reporting to us-east, so even worse) and we do a lot of queries—multiple per CID that the indexer says we know about. So my theory is that it's just not able to spit out the events fast enough to chew through the list and they're building up, blocking all the goroutines that we're spawning in `queryCandidates()` on the trip through filclient and back to the event reporter.

Querying the event database for number of events from the `'bedrock-dev'` instance over the last hour shows nearly ~11 events per second, which is probably a lot for my connection. (I think?)

So with this PR I'm attempting a few things:

1. Using an `http.Client` with a short timeout, I believe `DefaultClient` has no timeout
2. Reusing the same client (I don't know if calling `http.DefaultClient` results in reuse of the same resources? I'm hoping there's some possibilities for better connection management here)
3. Pushing off the actual event posting into a pool of goroutines which can chew through a channel with plenty of buffer

