### PR TITLE
feat: confirm retrievals resulted in a block in the blockstore

### DIFF
--- a/autoretrieve.go
+++ b/autoretrieve.go
@@ -27,6 +27,7 @@ import (
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/lotus/chain/wallet"
 	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/ipfs/go-cid"
 	flatfs "github.com/ipfs/go-ds-flatfs"
 	leveldb "github.com/ipfs/go-ds-leveldb"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
@@ -174,7 +175,11 @@ func New(cctx *cli.Context, dataDir string, cfg Config) (*Autoretrieve, error) {
 			return nil, err
 		}
 
-		retriever, err = filecoin.NewRetriever(cctx.Context, retrieverCfg, fc, ep, blockManager)
+		confirmer := func(c cid.Cid) (bool, error) {
+			return blockManager.Has(cctx.Context, c)
+		}
+
+		retriever, err = filecoin.NewRetriever(cctx.Context, retrieverCfg, fc, ep, confirmer)
 		if err != nil {
 			return nil, err
 		}

--- a/autoretrieve.go
+++ b/autoretrieve.go
@@ -174,7 +174,7 @@ func New(cctx *cli.Context, dataDir string, cfg Config) (*Autoretrieve, error) {
 			return nil, err
 		}
 
-		retriever, err = filecoin.NewRetriever(cctx.Context, retrieverCfg, fc, ep)
+		retriever, err = filecoin.NewRetriever(cctx.Context, retrieverCfg, fc, ep, blockManager)
 		if err != nil {
 			return nil, err
 		}

--- a/filecoin/eventrecorder/eventrecorder.go
+++ b/filecoin/eventrecorder/eventrecorder.go
@@ -77,6 +77,7 @@ type eventReport struct {
 type eventDetailsSuccess struct {
 	ReceivedSize uint64 `json:"receivedSize"`
 	ReceivedCids int64  `json:"receivedCids"`
+	Confirmed    bool   `json:"confirmed"`
 }
 
 // eventDetailsError is for the EventDetails in the case of a query or retrieval
@@ -120,9 +121,9 @@ func (er *EventRecorder) RetrievalProgress(retrievalId uuid.UUID, phaseStartTime
 // RetrievalSuccess events occur on the success of a retrieval. A retrieval
 // will result in either a QueryFailure or a QuerySuccess
 // event.
-func (er *EventRecorder) RetrievalSuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, retrievedSize uint64, receivedCids int64) {
+func (er *EventRecorder) RetrievalSuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, retrievalCid cid.Cid, storageProviderId peer.ID, retrievedSize uint64, receivedCids int64, confirmed bool) {
 	evt := eventReport{retrievalId, er.instanceId, retrievalCid.String(), storageProviderId, rep.RetrievalPhase, phaseStartTime, rep.SuccessCode, eventTime, nil}
-	evt.EventDetails = &eventDetailsSuccess{retrievedSize, receivedCids}
+	evt.EventDetails = &eventDetailsSuccess{retrievedSize, receivedCids, confirmed}
 	er.recordEvent("RetrievalSuccess", evt)
 }
 

--- a/filecoin/eventrecorder/eventrecorder_test.go
+++ b/filecoin/eventrecorder/eventrecorder_test.go
@@ -95,7 +95,7 @@ func TestEventRecorder(t *testing.T) {
 		{
 			name: "RetrievalSuccess",
 			exec: func(t *testing.T, ctx context.Context, er *eventrecorder.EventRecorder, id uuid.UUID, etime, ptime time.Time, spid peer.ID) {
-				er.RetrievalSuccess(id, ptime, etime, testCid1, spid, uint64(2020), 3030)
+				er.RetrievalSuccess(id, ptime, etime, testCid1, spid, uint64(2020), 3030, true)
 
 				select {
 				case <-ctx.Done():
@@ -117,9 +117,10 @@ func TestEventRecorder(t *testing.T) {
 
 				detailsNode, err := event.LookupByString("eventDetails")
 				qt.Assert(t, err, qt.IsNil)
-				qt.Assert(t, detailsNode.Length(), qt.Equals, int64(2))
+				qt.Assert(t, detailsNode.Length(), qt.Equals, int64(3))
 				verifyIntNode(t, detailsNode, "receivedSize", 2020)
 				verifyIntNode(t, detailsNode, "receivedCids", 3030)
+				verifyBoolNode(t, detailsNode, "confirmed", true)
 			},
 		},
 		{
@@ -274,6 +275,14 @@ func verifyIntNode(t *testing.T, node datamodel.Node, key string, expected int64
 	ii, err := subNode.AsInt()
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, ii, qt.Equals, expected)
+}
+
+func verifyBoolNode(t *testing.T, node datamodel.Node, key string, expected bool) {
+	subNode, err := node.LookupByString(key)
+	qt.Assert(t, err, qt.IsNil)
+	bb, err := subNode.AsBool()
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, bb, qt.Equals, expected)
 }
 
 func mustCid(cstr string) cid.Cid {

--- a/filecoin/retriever.go
+++ b/filecoin/retriever.go
@@ -95,9 +95,7 @@ type Endpoint interface {
 	FindCandidates(context.Context, cid.Cid) ([]RetrievalCandidate, error)
 }
 
-type BlockConfirmer interface {
-	Has(context.Context, cid.Cid) (bool, error)
-}
+type BlockConfirmer func(c cid.Cid) (bool, error)
 
 // Possible errors: ErrInitKeystoreFailed, ErrInitWalletFailed,
 // ErrInitFilClientFailed
@@ -119,9 +117,7 @@ func NewRetriever(
 			suspensionDuration:       time.Minute,
 			failureHistoryDuration:   time.Second * 15,
 		}),
-		confirm: func(c cid.Cid) (bool, error) {
-			return confirmer.Has(ctx, c)
-		},
+		confirm: confirmer,
 	}
 
 	retriever.filClient.SubscribeToRetrievalEvents(retriever)

--- a/filecoin/retrieverevents.go
+++ b/filecoin/retrieverevents.go
@@ -38,7 +38,7 @@ type RetrievalEventListener interface {
 	// RetrievalSuccess events occur on the success of a retrieval. A retrieval
 	// will result in either a QueryFailure or a QuerySuccess
 	// event.
-	RetrievalSuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, receivedSize uint64, receivedCids int64)
+	RetrievalSuccess(retrievalId uuid.UUID, phaseStartTime, eventTime time.Time, requestedCid cid.Cid, storageProviderId peer.ID, receivedSize uint64, receivedCids int64, confirmed bool)
 
 	// RetrievalFailure events occur on the failure of a retrieval. A retrieval
 	// will result in either a QueryFailure or a QuerySuccess
@@ -142,9 +142,9 @@ func (em *EventManager) FireRetrievalProgress(retrievalId uuid.UUID, requestedCi
 }
 
 // FireRetrievalSuccess calls RetrievalSuccess for all listeners
-func (em *EventManager) FireRetrievalSuccess(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, receivedSize uint64, receivedCids int64) {
+func (em *EventManager) FireRetrievalSuccess(retrievalId uuid.UUID, requestedCid cid.Cid, phaseStartTime time.Time, storageProviderId peer.ID, receivedSize uint64, receivedCids int64, confirmed bool) {
 	em.queueEvent(func(timestamp time.Time, listener RetrievalEventListener) {
-		listener.RetrievalSuccess(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, receivedSize, receivedCids)
+		listener.RetrievalSuccess(retrievalId, phaseStartTime, timestamp, requestedCid, storageProviderId, receivedSize, receivedCids, confirmed)
 	})
 }
 


### PR DESCRIPTION
Upon successful retrieval, provide a confirmation along with the reported event
that the retrieval resulted in the block being stored in the blockstore. Using
`retrievedCids` as a proxy isn't enough because it's possible (with some
non-trivial probability) that a retrieval takes place for a block that's just
been retrieved as part of a parallel retrieval, so graphsync doesn't need to
transfer any blocks.

The backstory for this is that we're seeing evidence of cases where a retrieval might look successful but doesn't result in any blocks being transferred that can't be explained by the block having already been in the blockstore. So now we get a `retrievedCids` int and a `confirmed` bool on the events. When we see a `confirmed` of `false` for a `"success"` event then it's a bug. The intended behaviour of the stack is that `"success"` is always confirmed.