### PR TITLE
feat: add more metrics

### DIFF
--- a/metrics/opentelemetry.go
+++ b/metrics/opentelemetry.go
@@ -8,21 +8,45 @@ import (
 
 // Measures
 var (
-	BitswapRequestCount          = stats.Int64("bitswap_request_total", "The number of bitswap requests received", stats.UnitDimensionless)
-	BitswapResponseCount         = stats.Int64("bitswap_response_total", "The number of bitswap responses", stats.UnitDimensionless)
-	BitswapRetrieverRequestCount = stats.Int64("bitswap_retriever_request_total", "The number of bitswap messages that required a retriever lookup", stats.UnitDimensionless)
-	BlockstoreCacheHitCount      = stats.Int64("blockstore_cache_hit_total", "The number of blocks from the local blockstore served to peers", stats.UnitDimensionless)
-	BytesTransferredTotal        = stats.Int64("data_transferred_bytes_total", "The number of bytes transferred from storage providers to retrieval clients", stats.UnitBytes)
-	RetrievalDealCost            = stats.Int64("retrieval_deal_cost_fil", "The cost in FIL of a retrieval deal with a storage provider", stats.UnitDimensionless)
-	RetrievalDealActiveCount     = stats.Int64("retrieval_deal_active_total", "The number of active retrieval deals that have not yet succeeded or failed", stats.UnitDimensionless)
-	RetrievalDealDuration        = stats.Float64("retrieval_deal_duration_seconds", "The duration in seconds of a retrieval deal with a storage provider", stats.UnitSeconds)
-	RetrievalDealFailCount       = stats.Int64("retrieval_deal_fail_total", "The number of failed retrieval deals with storage providers", stats.UnitDimensionless)
-	RetrievalDealSize            = stats.Int64("retrieval_deal_size_bytes", "The size in bytes of a retrieval deal with a storage provider", stats.UnitDimensionless)
-	RetrievalDealSuccessCount    = stats.Int64("retrieval_deal_success_total", "The number of successful retrieval deals with storage providers", stats.UnitDimensionless)
-	RetrievalRequestCount        = stats.Int64("retrieval_request_total", "The number of retrieval deals initiated with storage providers", stats.UnitDimensionless)
-	RetrievalResponseCount       = stats.Int64("retrieval_response_total", "The number of retrieval responses", stats.UnitDimensionless)
-	// TODO: Add counts for known retrieval failure cases
+	BitswapRequestCount                      = stats.Int64("bitswap_request_total", "The number of bitswap requests received", stats.UnitDimensionless)
+	BitswapResponseCount                     = stats.Int64("bitswap_response_total", "The number of bitswap responses", stats.UnitDimensionless)
+	BitswapRetrieverRequestCount             = stats.Int64("bitswap_retriever_request_total", "The number of bitswap messages that required a retriever lookup", stats.UnitDimensionless)
+	BlockstoreCacheHitCount                  = stats.Int64("blockstore_cache_hit_total", "The number of blocks from the local blockstore served to peers", stats.UnitDimensionless)
+	BytesTransferredTotal                    = stats.Int64("data_transferred_bytes_total", "The number of bytes transferred from storage providers to retrieval clients", stats.UnitBytes)
+	BitswapRequestWithIndexerCandidatesCount = stats.Int64("bitswap_request_with_indexer_candidates_total", "The number of bitswap requests that result in non-zero candidates from the indexer", stats.UnitDimensionless)
+	BitswapRequestWithSuccessfulQueryCount   = stats.Int64("bitswap_request_with_successful_query_total", "The number of bitswap requests that result in non-zero number of successful queries from SPs", stats.UnitDimensionless)
+	IndexerCandidatesCount                   = stats.Int64("indexer_candidates_total", "The retrieval candidates received from the indexer", stats.UnitDimensionless)
+	RetrievalQueryCount                      = stats.Int64("retrieval_request_total", "The number of retrieval deals initiated with storage providers", stats.UnitDimensionless)
+	RetrievalDealCost                        = stats.Int64("retrieval_deal_cost_fil", "The cost in FIL of a retrieval deal with a storage provider", stats.UnitDimensionless)
+	RetrievalDealActiveCount                 = stats.Int64("retrieval_deal_active_total", "The number of active retrieval deals that have not yet succeeded or failed", stats.UnitDimensionless)
+	RetrievalDealDuration                    = stats.Float64("retrieval_deal_duration_seconds", "The duration in seconds of a retrieval deal with a storage provider", stats.UnitSeconds)
+	RetrievalDealFailCount                   = stats.Int64("retrieval_deal_fail_total", "The number of failed retrieval deals with storage providers", stats.UnitDimensionless)
+	RetrievalDealSize                        = stats.Int64("retrieval_deal_size_bytes", "The size in bytes of a retrieval deal with a storage provider", stats.UnitDimensionless)
+	RetrievalDealSuccessCount                = stats.Int64("retrieval_deal_success_total", "The number of successful retrieval deals with storage providers", stats.UnitDimensionless)
+	RetrievalRequestCount                    = stats.Int64("retrieval_request_total", "The number of retrieval deals initiated with storage providers", stats.UnitDimensionless)
+	RetrievalResponseCount                   = stats.Int64("retrieval_response_total", "The number of retrieval responses", stats.UnitDimensionless)
+	RetrievalErrorPaychCount                 = stats.Int64("retrieval_error_paych_total", "The number of retrieval errors for 'failed to get payment channel'", stats.UnitDimensionless)
+	RetrievalErrorRejectedCount              = stats.Int64("retrieval_error_rejected_total", "The number of retrieval errors for 'response rejected'", stats.UnitDimensionless)
+	RetrievalErrorTooManyCount               = stats.Int64("retrieval_error_toomany_total", "The number of retrieval errors for 'Too many retrieval deals received'", stats.UnitDimensionless)
+	RetrievalErrorACLCount                   = stats.Int64("retrieval_error_acl_total", "The number of retrieval errors for 'Access Control'", stats.UnitDimensionless)
+	RetrievalErrorMaintenanceCount           = stats.Int64("retrieval_error_maintenance_total", "The number of retrieval errors for 'Under maintenance, retry later'", stats.UnitDimensionless)
+	RetrievalErrorNoOnlineCount              = stats.Int64("retrieval_error_noonline_total", "The number of retrieval errors for 'miner is not accepting online retrieval deals'", stats.UnitDimensionless)
+	RetrievalErrorUnconfirmedCount           = stats.Int64("retrieval_error_unconfirmed_total", "The number of retrieval errors for 'unconfirmed block transfer'", stats.UnitDimensionless)
+	RetrievalErrorOtherCount                 = stats.Int64("retrieval_error_other_total", "The number of retrieval errors with uncategorized causes", stats.UnitDimensionless)
 )
+
+// ErrorMetricMatches is a mapping of retrieval error message substrings (i.e.
+// that can be matched against error messages) and metrics to report for that
+// error.
+var ErrorMetricMatches = map[string]*stats.Int64Measure{
+	"failed to get payment channel":                 RetrievalErrorPaychCount,
+	"response rejected":                             RetrievalErrorRejectedCount,
+	"Too many retrieval deals received":             RetrievalErrorTooManyCount,
+	"Access Control":                                RetrievalErrorACLCount,
+	"Under maintenance, retry later":                RetrievalErrorMaintenanceCount,
+	"miner is not accepting online retrieval deals": RetrievalErrorNoOnlineCount,
+	"unconfirmed block transfer":                    RetrievalErrorUnconfirmedCount,
+}
 
 // Tags
 var (


### PR DESCRIPTION
Here's what I'm imagining for the dashboard with the addition of these metrics:

1. Measurement of the full pipeline from bitswap to retrieval, concentric circles getting smaller as we progress.
  a. `BitswapRetrieverRequestCount` (existing) is the total CIDs that we're attempting
  b. `BitswapRequestWithIndexerCandidatesCount` is the number that we have candidates for
  c. `BitswapRequestWithSuccessfulQueryCount` is the number that we have at least one successful query response for
  d. `RetrievalDealSuccessCount` is the number that we manage to retrieve
2. Additional data from the indexer and query phases:
  a. `IndexerCandidatesCount` tells us how many candidates we're getting from the indexer, we should be able to do things like divide it by `BitswapRequestWithIndexerCandidatesCount` to find the average number of candidates per found CID.
  b. `RetrievalQueryCount` is similar but for queries, we could divide by `BitswapRequestWithSuccessfulQueryCount` to get the average number of successful queries.
3. Accounting for specific errors: there's an error for each of the current top error types we're seeing that we'll do a `strings.Contains()` match on the error message for to match & report. Plus there's a `RetrievalErrorOtherCount` for the remainder which we can monitor and if it gets high enough we can add more. I'm imagining a table of these with %'s of the total failure count for each. Not sure if Grafana can do that yet but I'm sure it can do something similar.