### PR TITLE
feat: paid retrieval optional + bug fixes

### DIFF
--- a/config.go
+++ b/config.go
@@ -172,6 +172,7 @@ type Config struct {
 	LogResourceManager       bool                     `yaml:"log-resource-manager"`
 	LogRetrievals            bool                     `yaml:"log-retrieval-stats"`
 	DisableRetrieval         bool                     `yaml:"disable-retrieval"`
+	PaidRetrievals           bool                     `yaml:"paid-retrievals"`
 	CidBlacklist             []cid.Cid                `yaml:"cid-blacklist"`
 	MinerBlacklist           []ConfigStorageProvider  `yaml:"miner-blacklist"`
 	MinerWhitelist           []ConfigStorageProvider  `yaml:"miner-whitelist"`
@@ -184,7 +185,6 @@ type Config struct {
 
 // Extract relevant config points into a filecoin retriever config
 func (cfg *Config) ExtractFilecoinRetrieverConfig(ctx context.Context, fc *filclient.FilClient) (filecoin.RetrieverConfig, error) {
-
 	convertedMinerCfgs := make(map[peer.ID]filecoin.MinerConfig)
 	for provider, minerCfg := range cfg.MinerConfigs {
 		peer, err := provider.GetPeerID(ctx, fc)
@@ -210,6 +210,7 @@ func (cfg *Config) ExtractFilecoinRetrieverConfig(ctx context.Context, fc *filcl
 		MinerWhitelist:     whitelist,
 		DefaultMinerConfig: filecoin.MinerConfig(cfg.DefaultMinerConfig),
 		MinerConfigs:       convertedMinerCfgs,
+		PaidRetrievals:     cfg.PaidRetrievals,
 	}, nil
 }
 
@@ -249,6 +250,7 @@ func DefaultConfig() Config {
 		LogResourceManager: false,
 		LogRetrievals:      false,
 		DisableRetrieval:   false,
+		PaidRetrievals:     false,
 		CidBlacklist:       nil,
 		MinerBlacklist:     nil,
 		MinerWhitelist:     nil,

--- a/filecoin/retriever.go
+++ b/filecoin/retriever.go
@@ -200,15 +200,14 @@ func (retriever *Retriever) retrieveFromBestCandidate(ctx context.Context, retri
 
 	if !retriever.config.PaidRetrievals {
 		// filter out paid retrievals
-		ii := 0
+		qt := make([]candidateQuery, 0)
 		zero := big.Zero()
 		for _, q := range queries {
 			if totalCost(q.response).Equals(zero) {
-				queries[ii] = q
-				ii++
+				qt = append(qt, q)
 			}
 		}
-		queries = queries[:ii]
+		queries = qt
 	}
 
 	// register that we have this many candidates to retrieve from, so that when we

--- a/filecoin/retriever.go
+++ b/filecoin/retriever.go
@@ -450,7 +450,6 @@ func (retriever *Retriever) queryCandidates(ctx context.Context, retrievalId uui
 	wg.Add(len(candidates))
 
 	for i, candidate := range candidates {
-		candidate := candidate
 		go func(i int, candidate RetrievalCandidate) {
 			defer wg.Done()
 

--- a/filecoin/retriever_test.go
+++ b/filecoin/retriever_test.go
@@ -1,0 +1,168 @@
+package filecoin
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/application-research/filclient"
+	"github.com/application-research/filclient/rep"
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/peer"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestQueryFiltering(t *testing.T) {
+	testCases := []struct {
+		name           string
+		paid           bool
+		queryResponses map[string]retrievalmarket.QueryResponse
+		expectedPeers  []string
+	}{
+		{
+			name: "PaidRetrievals: true",
+			paid: true,
+			queryResponses: map[string]retrievalmarket.QueryResponse{
+				"foo": {Status: retrievalmarket.QueryResponseUnavailable},
+				"bar": {Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.NewInt(1), Size: 2, UnsealPrice: big.Zero()},
+				"baz": {Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.Zero(), Size: 2, UnsealPrice: big.Zero()},
+			},
+			expectedPeers: []string{"bar", "baz"},
+		},
+		{
+			name: "PaidRetrievals: false",
+			paid: false,
+			queryResponses: map[string]retrievalmarket.QueryResponse{
+				"foo": {Status: retrievalmarket.QueryResponseUnavailable},
+				"bar": {Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.NewInt(1), Size: 2, UnsealPrice: big.Zero()},
+				"baz": {Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.Zero(), Size: 2, UnsealPrice: big.Zero()},
+			},
+			expectedPeers: []string{"baz"},
+		},
+		{
+			name: "PaidRetrievals: true, /w only paid",
+			paid: true,
+			queryResponses: map[string]retrievalmarket.QueryResponse{
+				"foo": {Status: retrievalmarket.QueryResponseUnavailable},
+				"bar": {Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.NewInt(1), Size: 2, UnsealPrice: big.Zero()},
+				"baz": {Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.NewInt(1), Size: 2, UnsealPrice: big.Zero()},
+			},
+			expectedPeers: []string{"bar", "baz"},
+		},
+		{
+			name: "PaidRetrievals: false, /w only paid",
+			paid: false,
+			queryResponses: map[string]retrievalmarket.QueryResponse{
+				"foo": {Status: retrievalmarket.QueryResponseUnavailable},
+				"bar": {Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.NewInt(1), Size: 2, UnsealPrice: big.Zero()},
+				"baz": {Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.NewInt(1), Size: 2, UnsealPrice: big.Zero()},
+			},
+			expectedPeers: []string{},
+		},
+		{
+			name: "PaidRetrievals: true, w/ no paid",
+			paid: true,
+			queryResponses: map[string]retrievalmarket.QueryResponse{
+				"foo": {Status: retrievalmarket.QueryResponseUnavailable},
+				"bar": {Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.Zero(), Size: 2, UnsealPrice: big.Zero()},
+				"baz": {Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.Zero(), Size: 2, UnsealPrice: big.Zero()},
+			},
+			expectedPeers: []string{"bar", "baz"},
+		},
+		{
+			name: "PaidRetrievals: false, w/ no paid",
+			paid: false,
+			queryResponses: map[string]retrievalmarket.QueryResponse{
+				"foo": {Status: retrievalmarket.QueryResponseUnavailable},
+				"bar": {Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.Zero(), Size: 2, UnsealPrice: big.Zero()},
+				"baz": {Status: retrievalmarket.QueryResponseAvailable, MinPricePerByte: big.Zero(), Size: 2, UnsealPrice: big.Zero()},
+			},
+			expectedPeers: []string{"bar", "baz"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockFilc := &MockFilClient{returns_queryResponses: tc.queryResponses}
+			r, err := NewRetriever(context.Background(), RetrieverConfig{PaidRetrievals: tc.paid}, mockFilc, &DummyEndpoint{}, DummyBlockConfirmer)
+			qt.Assert(t, err, qt.IsNil)
+
+			candidates := []RetrievalCandidate{}
+			for p := range tc.queryResponses {
+				candidates = append(candidates, RetrievalCandidate{MinerPeer: peer.AddrInfo{ID: peer.ID(p)}})
+			}
+
+			// setup activeRetrievals to avoid an "unknown retrieval" error state
+			id, err := r.activeRetrievals.New(cid.Undef, len(candidates), 1)
+			qt.Assert(t, err, qt.IsNil)
+
+			// run retrieval as if `candidates` was the list the indexer provided
+			r.retrieveFromBestCandidate(context.Background(), id, cid.Undef, candidates)
+
+			// expected all queries
+			qt.Assert(t, len(mockFilc.received_queriedPeers), qt.Equals, len(tc.queryResponses))
+			for p := range tc.queryResponses {
+				qt.Assert(t, mockFilc.received_queriedPeers, qt.Contains, peer.ID(p))
+			}
+
+			// verify that the list of retrievals matches the expected filtered list
+			qt.Assert(t, len(mockFilc.received_retrievedPeers), qt.Equals, len(tc.expectedPeers))
+			for _, p := range tc.expectedPeers {
+				qt.Assert(t, mockFilc.received_retrievedPeers, qt.Contains, peer.ID(p))
+			}
+		})
+	}
+}
+
+var _ FilClient = (*MockFilClient)(nil)
+var _ Endpoint = (*DummyEndpoint)(nil)
+var _ BlockConfirmer = DummyBlockConfirmer
+
+type MockFilClient struct {
+	lk                      sync.Mutex
+	received_queriedPeers   []peer.ID
+	received_retrievedPeers []peer.ID
+
+	returns_queryResponses map[string]retrievalmarket.QueryResponse
+}
+
+func (dfc *MockFilClient) RetrievalQueryToPeer(ctx context.Context, minerPeer peer.AddrInfo, pcid cid.Cid) (*retrievalmarket.QueryResponse, error) {
+	dfc.lk.Lock()
+	dfc.received_queriedPeers = append(dfc.received_queriedPeers, minerPeer.ID)
+	dfc.lk.Unlock()
+
+	if qr, ok := dfc.returns_queryResponses[string(minerPeer.ID)]; ok {
+		return &qr, nil
+	}
+	return &retrievalmarket.QueryResponse{Status: retrievalmarket.QueryResponseUnavailable}, nil
+}
+
+func (dfc *MockFilClient) RetrieveContentFromPeerWithProgressCallback(
+	ctx context.Context,
+	peerID peer.ID,
+	minerWallet address.Address,
+	proposal *retrievalmarket.DealProposal,
+	progressCallback func(bytesReceived uint64),
+) (*filclient.RetrievalStats, error) {
+	dfc.lk.Lock()
+	dfc.received_retrievedPeers = append(dfc.received_retrievedPeers, peerID)
+	dfc.lk.Unlock()
+	return nil, errors.New("nope")
+}
+
+func (*MockFilClient) SubscribeToRetrievalEvents(subscriber rep.RetrievalSubscriber) {}
+
+type DummyEndpoint struct{}
+
+func (*DummyEndpoint) FindCandidates(context.Context, cid.Cid) ([]RetrievalCandidate, error) {
+	return []RetrievalCandidate{}, nil
+}
+
+func DummyBlockConfirmer(c cid.Cid) (bool, error) {
+	return true, nil
+}


### PR DESCRIPTION
"paid-retrievals" config option, defaulting to "false" will turn on attempting to retrieve from deals that are non-free. Otherwise, retrieval deals that are not free will be filtered. **NOTE** this changes the default behaviour such that paid retrievals need to be opted into. This _should_ make paych errors go away.

+Other bug fixes because I wrote a test for this and found some other things along the way!

* There's a closure bug for queries where we are skipping querying some candidates! Potentially missing out on a lot of retrievals (tbh I only learned that golang doesn't capture for loop variables within scope last week)
* Per-miner configs are not using defaults in some places because we're looking directly in the `MinerConfigs` map rather than calling the `MinerConfig()` method! I renamed it so it's not such a subtle difference now. The two main results of this are:
  1. There's no default max concurrent per SP! This could explain some complaints we've been getting.
  2. No default timeout for queries or retrievals, which may explain some leaky goroutines and weird resource usage stuff we've been seeing.