### PR TITLE
fix: filter candidates if we are _at_ or above the SP's max-concurrent

### DIFF
--- a/filecoin/retriever.go
+++ b/filecoin/retriever.go
@@ -441,7 +441,7 @@ func (retriever *Retriever) lookupCandidates(ctx context.Context, cid cid.Cid) (
 		// query is successful
 		minerConfig := retriever.config.GetMinerConfig(candidate.MinerPeer.ID)
 		if minerConfig.MaxConcurrentRetrievals > 0 &&
-			retriever.activeRetrievals.GetActiveRetrievalCountFor(candidate.MinerPeer.ID) > minerConfig.MaxConcurrentRetrievals {
+			retriever.activeRetrievals.GetActiveRetrievalCountFor(candidate.MinerPeer.ID) >= minerConfig.MaxConcurrentRetrievals {
 			continue
 		}
 


### PR DESCRIPTION
Currently it's >, not >=, but when it hits retrieval-proper it does a >= so candidates can make it through this step but fail at retrieval because they are maxxed out. This now matters because we are reporting metrics on the number candidates that get through.