### PR TITLE
feat: more information on already-running errors to see if there's leaks

### DIFF
--- a/filecoin/activeretrievals.go
+++ b/filecoin/activeretrievals.go
@@ -1,6 +1,7 @@
 package filecoin
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -73,8 +74,15 @@ func (arm *ActiveRetrievalsManager) New(retrievalCid cid.Cid, queryCandidateCoun
 	arm.lk.Lock()
 	defer arm.lk.Unlock()
 
-	if _, ok := arm.findActiveRetrievalFor(retrievalCid); ok {
-		return uuid.UUID{}, ErrRetrievalAlreadyRunning{retrievalCid}
+	if ar, ok := arm.findActiveRetrievalFor(retrievalCid); ok {
+		return uuid.UUID{}, ErrRetrievalAlreadyRunning{retrievalCid,
+			fmt.Sprintf("started %s ago, %d/%d query candidates, %d/%d retrieval candidates",
+				time.Since(ar.queryStartTime),
+				ar.queriesFinished,
+				ar.queryCandidateCount,
+				ar.retrievalsFinished,
+				ar.retrievalCandidateCount),
+		}
 	}
 
 	arm.arMap[retrievalCid] = &activeRetrieval{

--- a/filecoin/retriever.go
+++ b/filecoin/retriever.go
@@ -35,11 +35,12 @@ var (
 )
 
 type ErrRetrievalAlreadyRunning struct {
-	c cid.Cid
+	c     cid.Cid
+	extra string
 }
 
 func (e ErrRetrievalAlreadyRunning) Error() string {
-	return fmt.Sprintf("retrieval already running for cid: %s", e.c)
+	return fmt.Sprintf("retrieval already running for CID: %s (%s)", e.c, e.extra)
 }
 
 type MinerConfig struct {


### PR DESCRIPTION
We're seeing a lot more of these 'retrieval already running' errors than I'd expect in the logs after an instance has been running for ~half a day. This adds some additional information to the error message to help with tracking it down. Duration because if they've only been running for a few minutes then that's fine. Query/Retrieval expected & completion counts to tell us where they're held up, maybe we have missing events (like https://github.com/application-research/filclient/pull/104).