### PR TITLE
fix: timestamp test resolution - allow for millisecond boundary cross

### DIFF
--- a/filecoin/activeretrievals_test.go
+++ b/filecoin/activeretrievals_test.go
@@ -22,7 +22,7 @@ func TestActiveRetrievalsManager_GetStatusFor(t *testing.T) {
 	qt.Assert(t, has, qt.IsTrue)
 	qt.Assert(t, sid, qt.Equals, id)
 	qt.Assert(t, scid, qt.Equals, testCid1)
-	qt.Assert(t, sqtime.Truncate(time.Microsecond*1).UnixMilli(), qt.Equals, time.Now().Truncate(time.Microsecond*1).UnixMilli())
+	qt.Assert(t, time.Since(sqtime).Truncate(time.Millisecond).Milliseconds(), qt.Equals, int64(0))
 
 	_, _, _, has = arm.GetStatusFor(testCid2, rep.QueryPhase)
 	qt.Assert(t, has, qt.IsFalse)
@@ -42,7 +42,7 @@ func TestActiveRetrievalsManager_GetStatusFor(t *testing.T) {
 	qt.Assert(t, has, qt.IsTrue)
 	qt.Assert(t, sid, qt.Equals, id)
 	qt.Assert(t, scid, qt.Equals, testCid1)
-	qt.Assert(t, srtime.Truncate(time.Microsecond*1).UnixMilli(), qt.Equals, time.Now().Truncate(time.Microsecond*1).UnixMilli())
+	qt.Assert(t, time.Since(srtime).Truncate(time.Millisecond).Milliseconds(), qt.Equals, int64(0))
 	qt.Assert(t, srtime, qt.Not(qt.Equals), sqtime) // different phase start time
 
 	_, _, stime, has = arm.GetStatusFor(testCid1, rep.QueryPhase)


### PR DESCRIPTION
Flake experienced @ https://github.com/application-research/autoretrieve/actions/runs/3451782684/jobs/5761244626

I think this gives us a half-millisecond resolution rather than risking hitting right on the millisecond boundary and failing.