### PR TITLE
Use async retrieval for graceful shutdown on progress timeout

### DIFF
--- a/filecoin/eventrecorder/filelogserver/filelogserver.go
+++ b/filecoin/eventrecorder/filelogserver/filelogserver.go
@@ -1,9 +1,9 @@
 // A simple HTTP server that receives EventRecorder events and writes them,
 // as line-delimited JSON to an output file.
 //
-// 	* Use `--port` to set the port (default: 8080)
+//   - Use `--port` to set the port (default: 8080)
 //
-//  * Use `--output` to set the output file path (default: output.json)
+//   - Use `--output` to set the output file path (default: output.json)
 //
 // When encoded as JSON, the original event JSON will be wrapped in a parent
 // with the "retrievalId" UUID and "peerId" peerID that come from the URL.
@@ -13,7 +13,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -39,7 +39,7 @@ func main() {
 			return
 		}
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			log.Errorf("Could not decode body: %s", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/filecoin/retriever.go
+++ b/filecoin/retriever.go
@@ -352,8 +352,6 @@ func (retriever *Retriever) retrieve(ctx context.Context, query candidateQuery) 
 
 	minerCfgs := retriever.config.GetMinerConfig(query.candidate.MinerPeer.ID)
 
-	// Start the timeout tracker only if retrieval timeout isn't 0
-
 	resultChan, progressChan, gracefulShutdown := retriever.filClient.RetrieveContentFromPeerAsync(
 		retrieveCtx,
 		query.candidate.MinerPeer.ID,
@@ -361,6 +359,7 @@ func (retriever *Retriever) retrieve(ctx context.Context, query candidateQuery) 
 		proposal,
 	)
 
+	// Start the timeout tracker only if retrieval timeout isn't 0
 	if minerCfgs.RetrievalTimeout != 0 {
 		lastBytesReceivedTimer = time.AfterFunc(minerCfgs.RetrievalTimeout, func() {
 			doneLk.Lock()

--- a/filecoin/retriever_test.go
+++ b/filecoin/retriever_test.go
@@ -142,17 +142,18 @@ func (dfc *MockFilClient) RetrievalQueryToPeer(ctx context.Context, minerPeer pe
 	return &retrievalmarket.QueryResponse{Status: retrievalmarket.QueryResponseUnavailable}, nil
 }
 
-func (dfc *MockFilClient) RetrieveContentFromPeerWithProgressCallback(
+func (dfc *MockFilClient) RetrieveContentFromPeerAsync(
 	ctx context.Context,
 	peerID peer.ID,
 	minerWallet address.Address,
 	proposal *retrievalmarket.DealProposal,
-	progressCallback func(bytesReceived uint64),
-) (*filclient.RetrievalStats, error) {
+) (<-chan filclient.RetrievalResult, <-chan uint64, func()) {
 	dfc.lk.Lock()
 	dfc.received_retrievedPeers = append(dfc.received_retrievedPeers, peerID)
 	dfc.lk.Unlock()
-	return nil, errors.New("nope")
+	resChan := make(chan filclient.RetrievalResult, 1)
+	resChan <- filclient.RetrievalResult{nil, errors.New("nope")}
+	return resChan, nil, func() {}
 }
 
 func (*MockFilClient) SubscribeToRetrievalEvents(subscriber rep.RetrievalSubscriber) {}

--- a/filecoin/retriever_test.go
+++ b/filecoin/retriever_test.go
@@ -152,7 +152,7 @@ func (dfc *MockFilClient) RetrieveContentFromPeerAsync(
 	dfc.received_retrievedPeers = append(dfc.received_retrievedPeers, peerID)
 	dfc.lk.Unlock()
 	resChan := make(chan filclient.RetrievalResult, 1)
-	resChan <- filclient.RetrievalResult{nil, errors.New("nope")}
+	resChan <- filclient.RetrievalResult{RetrievalStats: nil, Err: errors.New("nope")}
 	return resChan, nil, func() {}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
-	github.com/application-research/filclient v0.3.1-0.20221116020041-6717b9e6b45f
+	github.com/application-research/filclient v0.3.1-0.20221116235316-9fc1b8b5b599
 	github.com/dustin/go-humanize v1.0.0
 	github.com/filecoin-project/go-address v1.0.0
 	github.com/filecoin-project/go-data-transfer v1.15.2

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0
-	github.com/application-research/filclient v0.2.1-0.20221015041616-ef7b47a4fe80
+	github.com/application-research/filclient v0.3.1-0.20221116020041-6717b9e6b45f
 	github.com/dustin/go-humanize v1.0.0
 	github.com/filecoin-project/go-address v1.0.0
 	github.com/filecoin-project/go-data-transfer v1.15.2

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/application-research/filclient v0.3.1-0.20221116020041-6717b9e6b45f h1:tP9wVf3VWA0/yRRNfb4P+6gCYeVlru51Yy5ksSkzE4U=
-github.com/application-research/filclient v0.3.1-0.20221116020041-6717b9e6b45f/go.mod h1:DQWX5A748TqK1TQdIRVM2vgzW+472Gr0bJ/4TpgTXaY=
+github.com/application-research/filclient v0.3.1-0.20221116235316-9fc1b8b5b599 h1:nkhMFVWi2QtbvjyTit7L9iEq2wPbT0+qJPJTGb2eqnc=
+github.com/application-research/filclient v0.3.1-0.20221116235316-9fc1b8b5b599/go.mod h1:DQWX5A748TqK1TQdIRVM2vgzW+472Gr0bJ/4TpgTXaY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,12 @@ github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/application-research/filclient v0.2.1-0.20221015041616-ef7b47a4fe80 h1:/PMhojSMvQF5S1kxYmR9K3S3kUvyhv9pFIZlVCyt32g=
 github.com/application-research/filclient v0.2.1-0.20221015041616-ef7b47a4fe80/go.mod h1:DQWX5A748TqK1TQdIRVM2vgzW+472Gr0bJ/4TpgTXaY=
+github.com/application-research/filclient v0.3.1-0.20221116014340-ee16d04c749c h1:vOMIry0n40+SmwItegfqvY0i+Y/sJu5NDaac+2FtDU4=
+github.com/application-research/filclient v0.3.1-0.20221116014340-ee16d04c749c/go.mod h1:DQWX5A748TqK1TQdIRVM2vgzW+472Gr0bJ/4TpgTXaY=
+github.com/application-research/filclient v0.3.1-0.20221116015418-17c646c9c136 h1:PizSgDVEwkpIyERryOTvzqVzmqHUo1Gxv0O8Lu2BrSM=
+github.com/application-research/filclient v0.3.1-0.20221116015418-17c646c9c136/go.mod h1:DQWX5A748TqK1TQdIRVM2vgzW+472Gr0bJ/4TpgTXaY=
+github.com/application-research/filclient v0.3.1-0.20221116020041-6717b9e6b45f h1:tP9wVf3VWA0/yRRNfb4P+6gCYeVlru51Yy5ksSkzE4U=
+github.com/application-research/filclient v0.3.1-0.20221116020041-6717b9e6b45f/go.mod h1:DQWX5A748TqK1TQdIRVM2vgzW+472Gr0bJ/4TpgTXaY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/go.sum
+++ b/go.sum
@@ -109,12 +109,6 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/application-research/filclient v0.2.1-0.20221015041616-ef7b47a4fe80 h1:/PMhojSMvQF5S1kxYmR9K3S3kUvyhv9pFIZlVCyt32g=
-github.com/application-research/filclient v0.2.1-0.20221015041616-ef7b47a4fe80/go.mod h1:DQWX5A748TqK1TQdIRVM2vgzW+472Gr0bJ/4TpgTXaY=
-github.com/application-research/filclient v0.3.1-0.20221116014340-ee16d04c749c h1:vOMIry0n40+SmwItegfqvY0i+Y/sJu5NDaac+2FtDU4=
-github.com/application-research/filclient v0.3.1-0.20221116014340-ee16d04c749c/go.mod h1:DQWX5A748TqK1TQdIRVM2vgzW+472Gr0bJ/4TpgTXaY=
-github.com/application-research/filclient v0.3.1-0.20221116015418-17c646c9c136 h1:PizSgDVEwkpIyERryOTvzqVzmqHUo1Gxv0O8Lu2BrSM=
-github.com/application-research/filclient v0.3.1-0.20221116015418-17c646c9c136/go.mod h1:DQWX5A748TqK1TQdIRVM2vgzW+472Gr0bJ/4TpgTXaY=
 github.com/application-research/filclient v0.3.1-0.20221116020041-6717b9e6b45f h1:tP9wVf3VWA0/yRRNfb4P+6gCYeVlru51Yy5ksSkzE4U=
 github.com/application-research/filclient v0.3.1-0.20221116020041-6717b9e6b45f/go.mod h1:DQWX5A748TqK1TQdIRVM2vgzW+472Gr0bJ/4TpgTXaY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
# Goals

Instead of cancelling context when a timeout occurs, attempt to gracefully close the data transfer channel. Uses filclient new Async version of retrieve