### PR TITLE
Add funnel filter metrics

### DIFF
--- a/metrics/opentelemetry.go
+++ b/metrics/opentelemetry.go
@@ -8,38 +8,48 @@ import (
 
 // Measures
 var (
-	BitswapRequestCount                      = stats.Int64("bitswap_request_total", "The number of bitswap requests received", stats.UnitDimensionless)
-	BitswapResponseCount                     = stats.Int64("bitswap_response_total", "The number of bitswap responses", stats.UnitDimensionless)
-	BitswapRetrieverRequestCount             = stats.Int64("bitswap_retriever_request_total", "The number of bitswap messages that required a retriever lookup", stats.UnitDimensionless)
-	BlockstoreCacheHitCount                  = stats.Int64("blockstore_cache_hit_total", "The number of blocks from the local blockstore served to peers", stats.UnitDimensionless)
-	BytesTransferredTotal                    = stats.Int64("data_transferred_bytes_total", "The number of bytes transferred from storage providers to retrieval clients", stats.UnitBytes)
-	BitswapRequestWithIndexerCandidatesCount = stats.Int64("bitswap_request_with_indexer_candidates_total", "The number of bitswap requests that result in non-zero candidates from the indexer", stats.UnitDimensionless)
-	BitswapRequestWithSuccessfulQueryCount   = stats.Int64("bitswap_request_with_successful_query_total", "The number of bitswap requests that result in non-zero number of successful queries from SPs", stats.UnitDimensionless)
-	IndexerCandidatesCount                   = stats.Int64("indexer_candidates_total", "The retrieval candidates received from the indexer", stats.UnitDimensionless)
-	RetrievalQueryCount                      = stats.Int64("retrieval_query_total", "The number of retrieval queries initiated with storage providers", stats.UnitDimensionless)
-	RetrievalDealCost                        = stats.Int64("retrieval_deal_cost_fil", "The cost in FIL of a retrieval deal with a storage provider", stats.UnitDimensionless)
-	RetrievalDealActiveCount                 = stats.Int64("retrieval_deal_active_total", "The number of active retrieval deals that have not yet succeeded or failed", stats.UnitDimensionless)
-	RetrievalDealDuration                    = stats.Float64("retrieval_deal_duration_seconds", "The duration in seconds of a retrieval deal with a storage provider", stats.UnitSeconds)
-	RetrievalDealFailCount                   = stats.Int64("retrieval_deal_fail_total", "The number of failed retrieval deals with storage providers", stats.UnitDimensionless)
-	RetrievalDealSize                        = stats.Int64("retrieval_deal_size_bytes", "The size in bytes of a retrieval deal with a storage provider", stats.UnitDimensionless)
-	RetrievalDealSuccessCount                = stats.Int64("retrieval_deal_success_total", "The number of successful retrieval deals with storage providers", stats.UnitDimensionless)
-	RetrievalRequestCount                    = stats.Int64("retrieval_request_total", "The number of retrieval deals initiated with storage providers", stats.UnitDimensionless)
-	RetrievalErrorPaychCount                 = stats.Int64("retrieval_error_paych_total", "The number of retrieval errors for 'failed to get payment channel'", stats.UnitDimensionless)
-	RetrievalErrorRejectedCount              = stats.Int64("retrieval_error_rejected_total", "The number of retrieval errors for 'response rejected'", stats.UnitDimensionless)
-	RetrievalErrorTooManyCount               = stats.Int64("retrieval_error_toomany_total", "The number of retrieval errors for 'Too many retrieval deals received'", stats.UnitDimensionless)
-	RetrievalErrorACLCount                   = stats.Int64("retrieval_error_acl_total", "The number of retrieval errors for 'Access Control'", stats.UnitDimensionless)
-	RetrievalErrorMaintenanceCount           = stats.Int64("retrieval_error_maintenance_total", "The number of retrieval errors for 'Under maintenance, retry later'", stats.UnitDimensionless)
-	RetrievalErrorNoOnlineCount              = stats.Int64("retrieval_error_noonline_total", "The number of retrieval errors for 'miner is not accepting online retrieval deals'", stats.UnitDimensionless)
-	RetrievalErrorUnconfirmedCount           = stats.Int64("retrieval_error_unconfirmed_total", "The number of retrieval errors for 'unconfirmed block transfer'", stats.UnitDimensionless)
-	RetrievalErrorTimeoutCount               = stats.Int64("retrieval_error_timeout_total", "The number of retrieval errors for 'timeout after X'", stats.UnitDimensionless)
-	RetrievalErrorOtherCount                 = stats.Int64("retrieval_error_other_total", "The number of retrieval errors with uncategorized causes", stats.UnitDimensionless)
-	QueryErrorFailedToDialCount              = stats.Int64("query_error_failed_to_dial", "The number of query errors because we coult not connect to the provider", stats.UnitDimensionless)
-	QueryErrorFailedToOpenStreamCount        = stats.Int64("query_error_failed_to_open_stream", "The number of query errors where the miner did not respond on the retrieval protocol", stats.UnitDimensionless)
-	QueryErrorResponseEOFCount               = stats.Int64("query_error_response_eof", "The number of query errors because where the response terminated early", stats.UnitDimensionless)
-	QueryErrorResponseStreamResetCount       = stats.Int64("query_error_response_stream_reset", "The number of query errors because where the response stream was reset", stats.UnitDimensionless)
-	QueryErrorDAGStoreCount                  = stats.Int64("query_error_dagstore", "The number of query failures cause the provider experienced a DAG Store error", stats.UnitDimensionless)
-	QueryErrorDealNotFoundCount              = stats.Int64("query_error_dealstate", "The number of query failures cause the provider couldn't find the relevant deal", stats.UnitDimensionless)
-	QueryErrorOtherCount                     = stats.Int64("query_error_error_other_total", "The number of retrieval errors with uncategorized causes", stats.UnitDimensionless)
+	BitswapRequestCount                = stats.Int64("bitswap_request_total", "The number of bitswap requests received", stats.UnitDimensionless)
+	BitswapResponseCount               = stats.Int64("bitswap_response_total", "The number of bitswap responses", stats.UnitDimensionless)
+	BitswapRetrieverRequestCount       = stats.Int64("bitswap_retriever_request_total", "The number of bitswap messages that required a retriever lookup", stats.UnitDimensionless)
+	BlockstoreCacheHitCount            = stats.Int64("blockstore_cache_hit_total", "The number of blocks from the local blockstore served to peers", stats.UnitDimensionless)
+	BytesTransferredTotal              = stats.Int64("data_transferred_bytes_total", "The number of bytes transferred from storage providers to retrieval clients", stats.UnitBytes)
+	RetrievalDealCost                  = stats.Int64("retrieval_deal_cost_fil", "The cost in FIL of a retrieval deal with a storage provider", stats.UnitDimensionless)
+	RetrievalDealActiveCount           = stats.Int64("retrieval_deal_active_total", "The number of active retrieval deals that have not yet succeeded or failed", stats.UnitDimensionless)
+	RetrievalDealDuration              = stats.Float64("retrieval_deal_duration_seconds", "The duration in seconds of a retrieval deal with a storage provider", stats.UnitSeconds)
+	RetrievalDealFailCount             = stats.Int64("retrieval_deal_fail_total", "The number of failed retrieval deals with storage providers", stats.UnitDimensionless)
+	RetrievalDealSize                  = stats.Int64("retrieval_deal_size_bytes", "The size in bytes of a retrieval deal with a storage provider", stats.UnitDimensionless)
+	RetrievalDealSuccessCount          = stats.Int64("retrieval_deal_success_total", "The number of successful retrieval deals with storage providers", stats.UnitDimensionless)
+	RetrievalRequestCount              = stats.Int64("retrieval_request_total", "The number of retrieval deals initiated with storage providers", stats.UnitDimensionless)
+	RetrievalErrorPaychCount           = stats.Int64("retrieval_error_paych_total", "The number of retrieval errors for 'failed to get payment channel'", stats.UnitDimensionless)
+	RetrievalErrorRejectedCount        = stats.Int64("retrieval_error_rejected_total", "The number of retrieval errors for 'response rejected'", stats.UnitDimensionless)
+	RetrievalErrorTooManyCount         = stats.Int64("retrieval_error_toomany_total", "The number of retrieval errors for 'Too many retrieval deals received'", stats.UnitDimensionless)
+	RetrievalErrorACLCount             = stats.Int64("retrieval_error_acl_total", "The number of retrieval errors for 'Access Control'", stats.UnitDimensionless)
+	RetrievalErrorMaintenanceCount     = stats.Int64("retrieval_error_maintenance_total", "The number of retrieval errors for 'Under maintenance, retry later'", stats.UnitDimensionless)
+	RetrievalErrorNoOnlineCount        = stats.Int64("retrieval_error_noonline_total", "The number of retrieval errors for 'miner is not accepting online retrieval deals'", stats.UnitDimensionless)
+	RetrievalErrorUnconfirmedCount     = stats.Int64("retrieval_error_unconfirmed_total", "The number of retrieval errors for 'unconfirmed block transfer'", stats.UnitDimensionless)
+	RetrievalErrorTimeoutCount         = stats.Int64("retrieval_error_timeout_total", "The number of retrieval errors for 'timeout after X'", stats.UnitDimensionless)
+	RetrievalErrorOtherCount           = stats.Int64("retrieval_error_other_total", "The number of retrieval errors with uncategorized causes", stats.UnitDimensionless)
+	QueryErrorFailedToDialCount        = stats.Int64("query_error_failed_to_dial", "The number of query errors because we coult not connect to the provider", stats.UnitDimensionless)
+	QueryErrorFailedToOpenStreamCount  = stats.Int64("query_error_failed_to_open_stream", "The number of query errors where the miner did not respond on the retrieval protocol", stats.UnitDimensionless)
+	QueryErrorResponseEOFCount         = stats.Int64("query_error_response_eof", "The number of query errors because where the response terminated early", stats.UnitDimensionless)
+	QueryErrorResponseStreamResetCount = stats.Int64("query_error_response_stream_reset", "The number of query errors because where the response stream was reset", stats.UnitDimensionless)
+	QueryErrorDAGStoreCount            = stats.Int64("query_error_dagstore", "The number of query failures cause the provider experienced a DAG Store error", stats.UnitDimensionless)
+	QueryErrorDealNotFoundCount        = stats.Int64("query_error_dealstate", "The number of query failures cause the provider couldn't find the relevant deal", stats.UnitDimensionless)
+	QueryErrorOtherCount               = stats.Int64("query_error_error_other_total", "The number of retrieval errors with uncategorized causes", stats.UnitDimensionless)
+
+	// Indexer Candidates
+	IndexerCandidatesPerRequestCount          = stats.Int64("indexer_candidates_per_request_total", "The number of indexer candidates received per request", stats.UnitDimensionless)
+	RequestWithIndexerCandidatesCount         = stats.Int64("request_with_indexer_candidates_total", "The number of requests that result in non-zero candidates from the indexer", stats.UnitDimensionless)
+	RequestWithIndexerCandidatesFilteredCount = stats.Int64("request_with_indexer_candidates_filtered_total", "The number of requests that result in non-zero candidates from the indexer after filtering", stats.UnitDimensionless)
+
+	// Query
+	RequestWithSuccessfulQueriesCount         = stats.Int64("request_with_successful_queries_total", "The number of requests that result in a non-zero number of successful queries from SPs", stats.UnitDimensionless)
+	RequestWithSuccessfulQueriesFilteredCount = stats.Int64("request_with_successful_queries_filtered_total", "The number of requests that result in a non-zero number of successful queries from SPs after filtering", stats.UnitDimensionless)
+	SuccessfulQueriesPerRequestCount          = stats.Int64("successful_queries_per_request_total", "The number of successful queries received per request", stats.UnitDimensionless)
+	SuccessfulQueriesPerRequestFilteredCount  = stats.Int64("successful_queries_per_request_filtered_total", "The number of successful queries received per request after filtering", stats.UnitDimensionless)
+
+	// Retrieval
+	FailedRetrievalsPerRequestCount = stats.Int64("failed_retrievals_per_request_total", "The number of failed retrieval attempts per request", stats.UnitDimensionless)
 )
 
 // QueryErrorMetricMatches is a mapping of retrieval error message substrings
@@ -108,21 +118,29 @@ var (
 		Measure:     BytesTransferredTotal,
 		Aggregation: view.Sum(),
 	}
-	bitswapRequestWithIndexerCandidatesView = &view.View{
-		Measure:     BitswapRequestWithIndexerCandidatesCount,
+	failedRetrievalsPerRequestView = &view.View{
+		Measure:     FailedRetrievalsPerRequestCount,
+		Aggregation: view.Distribution(0, 1, 2, 3, 4, 5, 10, 20, 40),
+	}
+	requestWithIndexerCandidatesFilteredView = &view.View{
+		Measure:     RequestWithIndexerCandidatesFilteredCount,
 		Aggregation: view.Count(),
 	}
-	bitswapRequestWithSuccessfulQueryView = &view.View{
-		Measure:     BitswapRequestWithSuccessfulQueryCount,
+	requestWithIndexerCandidatesView = &view.View{
+		Measure:     RequestWithIndexerCandidatesCount,
 		Aggregation: view.Count(),
 	}
-	indexerCandidatesView = &view.View{
-		Measure:     IndexerCandidatesCount,
+	requestWithSuccessfulQueriesFilteredView = &view.View{
+		Measure:     RequestWithSuccessfulQueriesFilteredCount,
 		Aggregation: view.Count(),
 	}
-	retrievalQueryView = &view.View{
-		Measure:     RetrievalQueryCount,
+	requestWithSuccessfulQueriesView = &view.View{
+		Measure:     RequestWithSuccessfulQueriesCount,
 		Aggregation: view.Count(),
+	}
+	indexerCandidatesPerRequestView = &view.View{
+		Measure:     IndexerCandidatesPerRequestCount,
+		Aggregation: view.Distribution(0, 1, 2, 3, 4, 5, 10, 20, 40),
 	}
 	retrievalDealActiveView = &view.View{
 		Measure:     RetrievalDealActiveCount,
@@ -188,6 +206,14 @@ var (
 		Measure:     RetrievalErrorOtherCount,
 		Aggregation: view.Count(),
 	}
+	successfulQueriesPerRequestFilteredView = &view.View{
+		Measure:     SuccessfulQueriesPerRequestFilteredCount,
+		Aggregation: view.Distribution(0, 1, 2, 3, 4, 5, 10, 20, 40),
+	}
+	successfulQueriesPerRequestView = &view.View{
+		Measure:     SuccessfulQueriesPerRequestCount,
+		Aggregation: view.Distribution(0, 1, 2, 3, 4, 5, 10, 20, 40),
+	}
 	queryErrorFailedToDialView = &view.View{
 		Measure:     QueryErrorFailedToDialCount,
 		Aggregation: view.Count(),
@@ -224,10 +250,12 @@ var DefaultViews = []*view.View{
 	bitswapRetreiverRequestView,
 	blockstoreCacheHitView,
 	bytesTransferredView,
-	bitswapRequestWithIndexerCandidatesView,
-	bitswapRequestWithSuccessfulQueryView,
-	indexerCandidatesView,
-	retrievalQueryView,
+	failedRetrievalsPerRequestView,
+	requestWithIndexerCandidatesFilteredView,
+	requestWithIndexerCandidatesView,
+	requestWithSuccessfulQueriesFilteredView,
+	requestWithSuccessfulQueriesView,
+	indexerCandidatesPerRequestView,
 	retrievalDealActiveView,
 	retrievalDealCostView,
 	retrievalDealDurationView,
@@ -244,6 +272,8 @@ var DefaultViews = []*view.View{
 	retrievalErrorUnconfirmedView,
 	retrievalErrorTimeoutView,
 	retrievalErrorOtherView,
+	successfulQueriesPerRequestFilteredView,
+	successfulQueriesPerRequestView,
 	queryErrorFailedToDialView,
 	queryErrorFailedToOpenStreamView,
 	queryErrorResponseEOFView,


### PR DESCRIPTION
Adds multiple metrics that help determine the number of requests being filtered out of each retrieval step, ie: indexer candidates, queries, and retrievals. Refactors some existing metrics and removes others that were not being used.

### Added
* **Indexer Candidates per Request**: A distribution of the number of indexer candidates we receive per request
* **Request with Indexer Candidates**: A count of the number of requests that result in non-zero candidates from the indexer
* **Request with Successful Queries**: A count of the number of requests that result in a non-zero number of successful queries from SPs
* **Successful Queries per Request**: A distribution of the number of successful queries received per request
* **Failed Retrievals per Request**: A distribution of the number of failed retrieval attempts from SPs per request

### Refactored
* **Bitswap Request with Indexer Candidates** -> **Request with Indexer Candidates Filtered**: A count of the number of requests that result in non-zero candidates from the indexer after filtering through allow lists and preventing concurrent retrievals from SPs.
* **Bitswap Request with Successful Query** -> **Request with Successful Queries Filtered**: A count of the number of requests that result in a non-zero number of successful queries from SPs after filtering out paid retrievals
* **Retrieval Query Count** -> **Successful Queries per Request Filtered**: A distribution of the number of successful queries received per request after filtering

### Removed
* **Indexer Candidates Count**: Wasn't being used

Pics of updated dashboard WIP

Fixes #137 