### PR TITLE
feat: move indexer-filtered metric after active-retrieval check

### DIFF
--- a/filecoin/retriever.go
+++ b/filecoin/retriever.go
@@ -172,8 +172,6 @@ func (retriever *Retriever) Request(cid cid.Cid) error {
 		return ErrNoCandidates
 	}
 
-	stats.Record(ctx, metrics.RequestWithIndexerCandidatesFilteredCount.M(1))
-
 	// when we want to include the indexer "phase", this should move to the top of
 	// Retrieve(), but for now we can avoid unnecessary new+cleanup for negative
 	// indexer calls.
@@ -189,6 +187,8 @@ func (retriever *Retriever) Request(cid cid.Cid) error {
 	if err != nil {
 		return err
 	}
+
+	stats.Record(ctx, metrics.RequestWithIndexerCandidatesFilteredCount.M(1))
 
 	// If we got to this point, one or more candidates have been found and we
 	// are good to go ahead with the retrieval


### PR DESCRIPTION
`activeRetrievals.New()` performs a "is this CID already involved in an active retrieval?" check and will return an `ErrRetrievalAlreadyRunning` if it is; move the index-filtered metric until after this point to capture this filtering in addition to the per-SP concurrency filtering.

I only realised this after watching logs while writing up details on the new funnel metrics .. It does mean we're combing two different filtering into one, but I _think_ that's OK for now. Better to not let this get lost because we lack a clear connection between "indexer candidates I can use" and "got a query response from at least one".