### PR TITLE
Don't put blocks on task queue

### DIFF
--- a/blocks/manager.go
+++ b/blocks/manager.go
@@ -14,7 +14,10 @@ import (
 
 var log = logging.Logger("blockstore")
 
-type Block = blocks.Block
+type Block struct {
+	Cid  cid.Cid
+	Size int
+}
 
 // Manager is a blockstore with thread safe notification hooking for put
 // events.
@@ -48,12 +51,12 @@ func NewManager(inner blockstore.Blockstore, getAwaitTimeout time.Duration) *Man
 	return mgr
 }
 
-func (mgr *Manager) GetAwait(ctx context.Context, cid cid.Cid, callback func(Block)) error {
+func (mgr *Manager) AwaitBlock(ctx context.Context, cid cid.Cid, callback func(Block)) error {
 	// We need to lock the blockstore here to make sure the requested block
 	// doesn't get added while being added to the waitlist
 	mgr.waitListLk.Lock()
 
-	block, err := mgr.Get(ctx, cid)
+	size, err := mgr.GetSize(ctx, cid)
 
 	// If we couldn't get the block, we add it to the waitlist - the block will
 	// be populated later during a Put or PutMany event
@@ -76,7 +79,7 @@ func (mgr *Manager) GetAwait(ctx context.Context, cid cid.Cid, callback func(Blo
 	mgr.waitListLk.Unlock()
 
 	// Otherwise, we can immediately run the callback
-	callback(block)
+	callback(Block{cid, size})
 
 	return nil
 }
@@ -90,7 +93,7 @@ func (mgr *Manager) Put(ctx context.Context, block blocks.Block) error {
 	}
 
 	select {
-	case mgr.readyBlocks <- block:
+	case mgr.readyBlocks <- Block{block.Cid(), len(block.RawData())}:
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -108,7 +111,7 @@ func (mgr *Manager) PutMany(ctx context.Context, blocks []blocks.Block) error {
 
 	for _, block := range blocks {
 		select {
-		case mgr.readyBlocks <- block:
+		case mgr.readyBlocks <- Block{block.Cid(), len(block.RawData())}:
 		case <-ctx.Done():
 			return ctx.Err()
 		}
@@ -124,7 +127,7 @@ func (mgr *Manager) startPollReadyBlocks() {
 }
 
 func (mgr *Manager) notifyWaitCallbacks(block Block) {
-	cid := block.Cid()
+	cid := block.Cid
 
 	mgr.waitListLk.Lock()
 	if entries, ok := mgr.waitList[cid]; ok {

--- a/blocks/manager_test.go
+++ b/blocks/manager_test.go
@@ -20,11 +20,11 @@ func TestPutBlock(t *testing.T) {
 	manager := NewManager(bs, 0)
 	blockGenerator := blocksutil.NewBlockGenerator()
 	blk := blockGenerator.Next()
-	receivedBlk := make(chan cid.Cid)
+	receivedBlk := make(chan Block)
 	errChan := make(chan error, 1)
 	go func() {
-		err := manager.GetAwait(ctx, blk.Cid(), func(blk Block) {
-			receivedBlk <- blk.Cid()
+		err := manager.AwaitBlock(ctx, blk.Cid(), func(blk Block) {
+			receivedBlk <- blk
 		})
 		if err != nil {
 			errChan <- err
@@ -39,9 +39,13 @@ func TestPutBlock(t *testing.T) {
 		t.Fatal("not enough succcesful blocks fetched")
 	case err := <-errChan:
 		t.Fatalf("received error getting block: %s", err)
-	case <-receivedBlk:
+	case received := <-receivedBlk:
+		if received.Cid != blk.Cid() && received.Size != len(blk.RawData()) {
+			t.Fatalf("received block bit with incorrect parameters")
+		}
 	}
 }
+
 func TestPutMany(t *testing.T) {
 	ctx := context.Background()
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
@@ -56,8 +60,8 @@ func TestPutMany(t *testing.T) {
 	errChan := make(chan error, 20)
 	go func() {
 		for _, blk := range blks {
-			err := manager.GetAwait(ctx, blk.Cid(), func(blk Block) {
-				receivedBlocks <- blk.Cid()
+			err := manager.AwaitBlock(ctx, blk.Cid(), func(blk Block) {
+				receivedBlocks <- blk.Cid
 			})
 			if err != nil {
 				errChan <- err
@@ -90,7 +94,7 @@ func TestCleanup(t *testing.T) {
 	gen := blocksutil.NewBlockGenerator()
 	for i := 0; i < testCount; i++ {
 		cid := gen.Next().Cid()
-		manager.GetAwait(ctx, cid, func(b blocks.Block) { t.Fatalf("This should not happen") })
+		manager.AwaitBlock(ctx, cid, func(b Block) { t.Fatalf("This should not happen") })
 	}
 
 	// manager.waitListLk.Lock()

--- a/blocks/randompruner.go
+++ b/blocks/randompruner.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	flatfs "github.com/ipfs/go-ds-flatfs"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
@@ -118,7 +119,7 @@ func (pruner *RandomPruner) DeleteBlock(ctx context.Context, cid cid.Cid) error 
 	return nil
 }
 
-func (pruner *RandomPruner) Put(ctx context.Context, block Block) error {
+func (pruner *RandomPruner) Put(ctx context.Context, block blocks.Block) error {
 	pruner.updatePin(block.Cid())
 	pruner.Poll(ctx)
 	if err := pruner.Blockstore.Put(ctx, block); err != nil {
@@ -130,7 +131,7 @@ func (pruner *RandomPruner) Put(ctx context.Context, block Block) error {
 	return nil
 }
 
-func (pruner *RandomPruner) PutMany(ctx context.Context, blocks []Block) error {
+func (pruner *RandomPruner) PutMany(ctx context.Context, blocks []blocks.Block) error {
 	blocksSize := 0
 	for _, block := range blocks {
 		pruner.updatePin(block.Cid())


### PR DESCRIPTION
# Goal

We have chronic memory usage issues with Bedrock's autoretrieve instance. Memory allocated in go-graphsync upon receipt of new blocks makes it's way into autoretrieve's blocks.Manager.Put calls and then all the way into bitswap's peer task queue. With the default config of only one Bitswap message sending worker, this means under heavy bitswap requests, huge sets of block data are being put on the task queue as "Topic"s. They're held from the time a retrieval gets a block to the time a block gets to the top of the task queue to send over the wire. These topics, while a blank interface, were never meant to hold large objects like blocks, only intentifiers of data like cids, or other smaller items. This PR reverts them back to CIDs, like go-bitswap uses, and only reads them back off disk when a block is sending.

# Implementation

- Change the block managers GetAwait to be called "AwaitBlock" -- indicating you're just waiting for the block to be present, not actually getting all it's data 
- the call back now only returns a cid & block size, which is sufficient to put the task onto the queue even for a wantBlock
- modify the message send code to read blocks blocks from disk at the time of moving them over the wire