### PR TITLE
fix: block wait timeout & more provider & block debugging

### DIFF
--- a/bitswap/provider.go
+++ b/bitswap/provider.go
@@ -202,8 +202,8 @@ func (provider *Provider) ReceiveMessage(ctx context.Context, sender peer.ID, in
 				continue
 			}
 
-			if err := provider.blockManager.AwaitBlock(ctx, entry.Cid, func(_ blocks.Block, err error) {
-				if err != nil { // likely a timeout
+			provider.blockManager.AwaitBlock(ctx, entry.Cid, func(_ blocks.Block, err error) {
+				if err != nil {
 					logger.Debugf("Failed to load block: %s", err.Error())
 					provider.queueDontHave(ctx, sender, entry, "failed_block_load")
 				} else {
@@ -211,10 +211,7 @@ func (provider *Provider) ReceiveMessage(ctx context.Context, sender peer.ID, in
 					provider.queueHave(context.Background(), sender, entry)
 				}
 				provider.signalWork()
-			}); err != nil {
-				logger.Errorf("Failed to load block: %s", err.Error())
-				provider.queueDontHave(ctx, sender, entry, "failed_block_load")
-			}
+			})
 		case wantTypeBlock:
 			if err := provider.retriever.Request(entry.Cid); err != nil {
 				// If no candidates were found, there's nothing that can be done, so
@@ -228,8 +225,8 @@ func (provider *Provider) ReceiveMessage(ctx context.Context, sender peer.ID, in
 				continue
 			}
 
-			if err := provider.blockManager.AwaitBlock(ctx, entry.Cid, func(block blocks.Block, err error) {
-				if err != nil { // likely a timeout
+			provider.blockManager.AwaitBlock(ctx, entry.Cid, func(block blocks.Block, err error) {
+				if err != nil {
 					logger.Debugf("Failed to load block: %s", err.Error())
 					provider.queueDontHave(ctx, sender, entry, "failed_block_load")
 				} else {
@@ -237,10 +234,7 @@ func (provider *Provider) ReceiveMessage(ctx context.Context, sender peer.ID, in
 					provider.queueBlock(context.Background(), sender, entry, block.Size)
 				}
 				provider.signalWork()
-			}); err != nil {
-				logger.Errorf("Failed to load block: %s", err.Error())
-				provider.queueDontHave(ctx, sender, entry, "failed_block_load")
-			}
+			})
 		}
 	}
 

--- a/bitswap/provider.go
+++ b/bitswap/provider.go
@@ -202,8 +202,14 @@ func (provider *Provider) ReceiveMessage(ctx context.Context, sender peer.ID, in
 				continue
 			}
 
-			if err := provider.blockManager.AwaitBlock(ctx, entry.Cid, func(_ blocks.Block) {
-				provider.queueHave(context.Background(), sender, entry)
+			if err := provider.blockManager.AwaitBlock(ctx, entry.Cid, func(_ blocks.Block, err error) {
+				if err != nil { // likely a timeout
+					logger.Debugf("Failed to load block: %s", err.Error())
+					provider.queueDontHave(ctx, sender, entry, "failed_block_load")
+				} else {
+					logger.Debugf("Successfully awaited block (want_have): %s", entry.Cid)
+					provider.queueHave(context.Background(), sender, entry)
+				}
 				provider.signalWork()
 			}); err != nil {
 				logger.Errorf("Failed to load block: %s", err.Error())
@@ -222,8 +228,14 @@ func (provider *Provider) ReceiveMessage(ctx context.Context, sender peer.ID, in
 				continue
 			}
 
-			if err := provider.blockManager.AwaitBlock(ctx, entry.Cid, func(block blocks.Block) {
-				provider.queueBlock(context.Background(), sender, entry, block.Size)
+			if err := provider.blockManager.AwaitBlock(ctx, entry.Cid, func(block blocks.Block, err error) {
+				if err != nil { // likely a timeout
+					logger.Debugf("Failed to load block: %s", err.Error())
+					provider.queueDontHave(ctx, sender, entry, "failed_block_load")
+				} else {
+					logger.Debugf("Successfully awaited block (want_block): %s", entry.Cid)
+					provider.queueBlock(context.Background(), sender, entry, block.Size)
+				}
 				provider.signalWork()
 			}); err != nil {
 				logger.Errorf("Failed to load block: %s", err.Error())
@@ -274,14 +286,26 @@ func (provider *Provider) runWorker() {
 		for _, task := range tasks {
 			switch topic := task.Topic.(type) {
 			case topicHave:
-				msg.AddHave(cid.Cid(topic))
+				have, err := provider.blockManager.Has(context.Background(), cid.Cid(topic))
+				if err != nil {
+					logger.Errorf("Block load error: %s", err.Error())
+					msg.AddDontHave(cid.Cid(topic))
+				} else if !have {
+					logger.Debugf("Had a block but lost it for want_have: %s", cid.Cid(topic))
+					msg.AddDontHave(cid.Cid(topic))
+				} else {
+					logger.Debugf("Sending want_have to peer: %s", cid.Cid(topic))
+					msg.AddHave(cid.Cid(topic))
+				}
 			case topicDontHave:
 				msg.AddDontHave(cid.Cid(topic))
 			case topicBlock:
 				blk, err := provider.blockManager.Get(context.Background(), cid.Cid(topic))
 				if err != nil {
+					logger.Debugf("Had a block but lost it for want_block: %s (%s)", cid.Cid(topic), err.Error())
 					msg.AddDontHave(cid.Cid(topic))
 				} else {
+					logger.Debugf("Sending want_block to peer: %s", cid.Cid(topic))
 					msg.AddBlock(blk)
 				}
 			}

--- a/blocks/manager.go
+++ b/blocks/manager.go
@@ -2,6 +2,7 @@ package blocks
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -13,6 +14,8 @@ import (
 )
 
 var log = logging.Logger("blockstore")
+
+var ErrWaitTimeout = errors.New("wait timeout for block")
 
 type Block struct {
 	Cid  cid.Cid
@@ -30,15 +33,16 @@ type Manager struct {
 }
 
 type waitListEntry struct {
-	callback     func(Block)
+	callback     func(Block, error)
 	registeredAt time.Time
 }
 
 func NewManager(inner blockstore.Blockstore, getAwaitTimeout time.Duration) *Manager {
 	mgr := &Manager{
-		Blockstore:  inner,
-		readyBlocks: make(chan Block, 10),
-		waitList:    make(map[cid.Cid][]waitListEntry),
+		Blockstore:      inner,
+		readyBlocks:     make(chan Block, 10),
+		waitList:        make(map[cid.Cid][]waitListEntry),
+		getAwaitTimeout: getAwaitTimeout,
 	}
 
 	go mgr.startPollReadyBlocks()
@@ -51,7 +55,7 @@ func NewManager(inner blockstore.Blockstore, getAwaitTimeout time.Duration) *Man
 	return mgr
 }
 
-func (mgr *Manager) AwaitBlock(ctx context.Context, cid cid.Cid, callback func(Block)) error {
+func (mgr *Manager) AwaitBlock(ctx context.Context, cid cid.Cid, callback func(Block, error)) error {
 	// We need to lock the blockstore here to make sure the requested block
 	// doesn't get added while being added to the waitlist
 	mgr.waitListLk.Lock()
@@ -72,14 +76,13 @@ func (mgr *Manager) AwaitBlock(ctx context.Context, cid cid.Cid, callback func(B
 		})
 
 		mgr.waitListLk.Unlock()
-
 		return nil
 	}
 
 	mgr.waitListLk.Unlock()
 
 	// Otherwise, we can immediately run the callback
-	callback(Block{cid, size})
+	callback(Block{cid, size}, nil)
 
 	return nil
 }
@@ -128,15 +131,17 @@ func (mgr *Manager) startPollReadyBlocks() {
 
 func (mgr *Manager) notifyWaitCallbacks(block Block) {
 	cid := block.Cid
-
 	mgr.waitListLk.Lock()
-	if entries, ok := mgr.waitList[cid]; ok {
+	entries, ok := mgr.waitList[cid]
+	if ok {
 		delete(mgr.waitList, cid)
-		for _, entry := range entries {
-			entry.callback(block)
-		}
 	}
 	mgr.waitListLk.Unlock()
+	if ok {
+		for _, entry := range entries {
+			entry.callback(block, nil)
+		}
+	}
 }
 
 func (mgr *Manager) startPollCleanup() {
@@ -150,6 +155,7 @@ func (mgr *Manager) startPollCleanup() {
 					// ...and if so, delete this element by replacing it with
 					// the last element of the slice and shrinking the length by
 					// 1, and step the index back
+					mgr.waitList[cid][i].callback(Block{}, ErrWaitTimeout)
 					mgr.waitList[cid][i] = mgr.waitList[cid][len(mgr.waitList[cid])-1]
 					mgr.waitList[cid] = mgr.waitList[cid][:len(mgr.waitList[cid])-1]
 					i--

--- a/blocks/manager_test.go
+++ b/blocks/manager_test.go
@@ -23,7 +23,7 @@ func TestPutBlock(t *testing.T) {
 	receivedBlk := make(chan Block)
 	errChan := make(chan error, 1)
 	go func() {
-		err := manager.AwaitBlock(ctx, blk.Cid(), func(blk Block) {
+		err := manager.AwaitBlock(ctx, blk.Cid(), func(blk Block, err error) {
 			receivedBlk <- blk
 		})
 		if err != nil {
@@ -60,7 +60,7 @@ func TestPutMany(t *testing.T) {
 	errChan := make(chan error, 20)
 	go func() {
 		for _, blk := range blks {
-			err := manager.AwaitBlock(ctx, blk.Cid(), func(blk Block) {
+			err := manager.AwaitBlock(ctx, blk.Cid(), func(blk Block, err error) {
 				receivedBlocks <- blk.Cid
 			})
 			if err != nil {
@@ -94,7 +94,11 @@ func TestCleanup(t *testing.T) {
 	gen := blocksutil.NewBlockGenerator()
 	for i := 0; i < testCount; i++ {
 		cid := gen.Next().Cid()
-		manager.AwaitBlock(ctx, cid, func(b Block) { t.Fatalf("This should not happen") })
+		manager.AwaitBlock(ctx, cid, func(b Block, err error) {
+			if err != ErrWaitTimeout {
+				t.Fatalf("This should not happen")
+			}
+		})
 	}
 
 	// manager.waitListLk.Lock()

--- a/blocks/manager_test.go
+++ b/blocks/manager_test.go
@@ -23,12 +23,13 @@ func TestPutBlock(t *testing.T) {
 	receivedBlk := make(chan Block)
 	errChan := make(chan error, 1)
 	go func() {
-		err := manager.AwaitBlock(ctx, blk.Cid(), func(blk Block, err error) {
-			receivedBlk <- blk
+		manager.AwaitBlock(ctx, blk.Cid(), func(blk Block, err error) {
+			if err != nil {
+				errChan <- err
+			} else {
+				receivedBlk <- blk
+			}
 		})
-		if err != nil {
-			errChan <- err
-		}
 	}()
 	err := manager.Put(ctx, blk)
 	if err != nil {
@@ -60,12 +61,13 @@ func TestPutMany(t *testing.T) {
 	errChan := make(chan error, 20)
 	go func() {
 		for _, blk := range blks {
-			err := manager.AwaitBlock(ctx, blk.Cid(), func(blk Block, err error) {
-				receivedBlocks <- blk.Cid
+			manager.AwaitBlock(ctx, blk.Cid(), func(blk Block, err error) {
+				if err != nil {
+					errChan <- err
+				} else {
+					receivedBlocks <- blk.Cid
+				}
 			})
-			if err != nil {
-				errChan <- err
-			}
 		}
 	}()
 	err := manager.PutMany(ctx, blks)


### PR DESCRIPTION
* lots of block provider debugging messages so you can see the passage of blocks through to the bitswap message
* provide a timeout error on the `AwaitBlock` callback so you can do something with it in that case (including sending a dont_have, although that might be silly 10 minutes late?)
* properly wire up the AwaitBlock timeout to the BlockManager instantiation