### PR TITLE
Log startup error

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,6 +174,7 @@ func cmd(ctx *cli.Context) error {
 
 	autoretrieve, err := New(ctx, dataDirPath(ctx), cfg)
 	if err != nil {
+		logger.Errorf("Error starting autoretrieve: %s", err.Error())
 		return err
 	}
 


### PR DESCRIPTION
log errors if autoretrieve does not start