### PR TITLE
feat: watch for pushes to staging branch for ecr publish

### DIFF
--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           IMAGE_TAG="${GITHUB_REF#refs/tags/v}"
           if test "${IMAGE_TAG}" = "${GITHUB_REF}"; then
-            IMAGE_TAG="$(date '+%Y%m%d%H%M%S')-${GITHUB_SHA}"
+            IMAGE_TAG="$(date '+%Y%m%d%H%M%S')-${GITHUB_REF##*/}-${GITHUB_SHA}"
           fi
           echo "Using image tag: ${IMAGE_TAG}"
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV

--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
     branches:
       - master
+      - staging
 
 jobs:
   publisher:


### PR DESCRIPTION
I'm presuming https://github.com/filecoin-project/autoretrieve-deploy/blob/main/.github/workflows/cd.yml will pick it up from an AWS push to the cd/dev branch there?