### PR TITLE
Cache all cids in memory in pruner

### DIFF
--- a/blocks/randompruner.go
+++ b/blocks/randompruner.go
@@ -136,8 +136,8 @@ func (pruner *RandomPruner) DeleteBlock(ctx context.Context, cid cid.Cid) error 
 	pruner.size -= uint64(blockSize)
 	pruner.allCidsLk.Lock()
 	cs, ok := pruner.allCids[cid]
-	delete(pruner.allCids, cid)
 	if ok {
+		delete(pruner.allCids, cid)
 		cidStatusPool.Put(cs)
 	}
 	pruner.allCidsLk.Unlock()

--- a/blocks/randompruner.go
+++ b/blocks/randompruner.go
@@ -270,6 +270,10 @@ func (pruner *RandomPruner) prune(ctx context.Context, bytesToPrune uint64) erro
 		status.pinned = false
 
 		paddedCidStr := fmt.Sprintf("%-*s", cidPadLength, cid.String())
+		if len(paddedCidStr) > cidPadLength {
+			paddedCidStr = paddedCidStr[:cidPadLength]
+		}
+)
 		if _, err := writer.WriteString(paddedCidStr + "\n"); err != nil {
 			pruner.allCidsLk.Unlock()
 			return fmt.Errorf("failed to write cid to tmp file: %w", err)

--- a/blocks/randompruner.go
+++ b/blocks/randompruner.go
@@ -273,7 +273,6 @@ func (pruner *RandomPruner) prune(ctx context.Context, bytesToPrune uint64) erro
 		if len(paddedCidStr) > cidPadLength {
 			paddedCidStr = paddedCidStr[:cidPadLength]
 		}
-)
 		if _, err := writer.WriteString(paddedCidStr + "\n"); err != nil {
 			pruner.allCidsLk.Unlock()
 			return fmt.Errorf("failed to write cid to tmp file: %w", err)

--- a/blocks/randompruner.go
+++ b/blocks/randompruner.go
@@ -263,7 +263,6 @@ func (pruner *RandomPruner) prune(ctx context.Context, bytesToPrune uint64) erro
 
 	pruner.allCidsLk.Lock()
 	for cid, status := range pruner.allCids {
-
 		if status.pinned && time.Since(status.pinTime) < pruner.pinDuration {
 			continue
 		}


### PR DESCRIPTION
# Goals

Performance testing indicates the pruner is still a huge bottleneck on performance, and the hot spot is reading the all keys chan.

By our calculations, with not too much penalty we can keep a list of all keys in memory, and thus avoid this bottleneck.

# Implementation

- instead of tracking pins, track all cids including whether they are pinned
- periodically sync with disk
- use a sync.Pool to avoid unneeded allocations

# For discussion

This is complicated enough I want to write tests before anyone merges it, but want folks to review the approach now.